### PR TITLE
Surface live telemetry safety metrics and add grader debug toggle

### DIFF
--- a/components/RunDetailClient.tsx
+++ b/components/RunDetailClient.tsx
@@ -7,6 +7,7 @@ import StatusBadge from "./StatusBadge";
 import TelemetryStrip from "./TelemetryStrip";
 import {
   ChevronRight, Wrench, Clock, Hash, Cpu, DollarSign, Loader2, CircleDot, Gauge,
+  Eye, EyeOff,
 } from "lucide-react";
 import type { RunCaseRecord } from "@/lib/types";
 
@@ -16,6 +17,7 @@ export default function RunDetailClient({ runId, initialCases, running }: Props)
   const [cases, setCases] = useState<RunCaseRecord[]>(initialCases);
   const [selectedIdx, setSelectedIdx] = useState<number | null>(initialCases.length ? 0 : null);
   const [live, setLive] = useState(running);
+  const [debug, setDebug] = useState(false);
   const lastSig = useRefSig(cases);
 
   useEffect(() => {
@@ -70,6 +72,10 @@ export default function RunDetailClient({ runId, initialCases, running }: Props)
           {cases.map((c, i) => {
             const sel = selectedIdx === i;
             const runner = c.runner_result;
+            const tokPerSec = runner && runner.durationMs > 0
+              ? (runner.usage.outputTokens / (runner.durationMs / 1000)).toFixed(1)
+              : "—";
+            const cost = runner ? `$${runner.usage.costUsd.toFixed(4)}` : "—";
             return (
               <button
                 key={c.id}
@@ -87,6 +93,12 @@ export default function RunDetailClient({ runId, initialCases, running }: Props)
                     {runner && <span>· turns {runner.numTurns} · {runner.toolCalls.length} tools</span>}
                   </div>
                 </div>
+                {runner && (
+                  <div className="hidden md:flex flex-col items-end text-[10px] mono text-fg-dim gap-0.5 mr-1">
+                    <span>{tokPerSec} tok/s</span>
+                    <span>{cost}</span>
+                  </div>
+                )}
                 <StatusBadge status={c.status} size="xs" />
               </button>
             );
@@ -102,7 +114,7 @@ export default function RunDetailClient({ runId, initialCases, running }: Props)
             <div className="text-[11px] text-fg-dim mt-1">Live transcript and grading results available after completion</div>
           </div>
         ) : (
-          <CaseSidePanel key={cases[selectedIdx].id} rc={cases[selectedIdx]} runId={runId} />
+          <CaseSidePanel key={cases[selectedIdx].id} rc={cases[selectedIdx]} runId={runId} debug={debug} setDebug={setDebug} />
         )}
       </section>
       </div>
@@ -110,7 +122,7 @@ export default function RunDetailClient({ runId, initialCases, running }: Props)
   );
 }
 
-function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
+function CaseSidePanel({ rc, runId, debug, setDebug }: { rc: RunCaseRecord; runId: string; debug: boolean; setDebug: (v: boolean) => void; }) {
   const runner = rc.runner_result;
   const grader = rc.grader_result;
   return (
@@ -141,9 +153,22 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
         <div className="card overflow-hidden">
           <div className="px-4 py-2.5 border-b border-bd-subtle bg-bg-subtle/50 flex items-center justify-between">
             <span className="text-xs font-medium">Graders</span>
-            <span className={clsx("text-xs mono font-semibold", grader.passed ? "text-ok" : "text-err")}>
-              {(grader.passRatio * 100).toFixed(0)}%
-            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setDebug(!debug)}
+                className={clsx(
+                  "flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] mono border border-bd-subtle transition-colors",
+                  debug ? "bg-accent/10 text-accent-soft" : "text-fg-muted hover:text-fg"
+                )}
+                aria-pressed={debug}
+              >
+                {debug ? <EyeOff className="size-3" /> : <Eye className="size-3" />}
+                Debug
+              </button>
+              <span className={clsx("text-xs mono font-semibold", grader.passed ? "text-ok" : "text-err")}>
+                {(grader.passRatio * 100).toFixed(0)}%
+              </span>
+            </div>
           </div>
           <div className="divide-y divide-bd-subtle">
             {grader.results.map((g, i) => (
@@ -156,7 +181,7 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
                       <span className="text-[10px] text-fg-dim mono">{g.durationMs}ms</span>
                     </div>
                     <div className="text-[11px] text-fg-muted mt-1 break-words">{g.detail}</div>
-                    {g.output && <pre className="mt-1.5 text-[10px] mono text-fg-dim bg-bg p-2 rounded border border-bd-subtle overflow-x-auto max-h-40 overflow-y-auto">{g.output.slice(0, 2000)}</pre>}
+                    {debug && g.output && <pre className="mt-1.5 text-[10px] mono text-fg-dim bg-bg p-2 rounded border border-bd-subtle overflow-x-auto max-h-80 overflow-y-auto">{g.output}</pre>}
                   </div>
                 </div>
               </div>

--- a/components/TelemetryStrip.tsx
+++ b/components/TelemetryStrip.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Gauge, Timer, Layers, AlertTriangle, Hash, Wrench, BarChart3 } from "lucide-react";
+import clsx from "clsx";
+import { Gauge, Timer, Layers, AlertTriangle, Hash, Wrench, BarChart3, DollarSign, Bug, Shield, ShieldCheck } from "lucide-react";
 import type { RunTelemetry } from "@/lib/types";
 
 export default function TelemetryStrip({ runId }: { runId: string }) {
@@ -34,13 +35,16 @@ export default function TelemetryStrip({ runId }: { runId: string }) {
           <BarChart3 className="size-3" /> Full bench
         </Link>
       </div>
-      <div className="grid grid-cols-3 md:grid-cols-6 lg:grid-cols-9 gap-2">
+      <div className="grid grid-cols-3 md:grid-cols-6 lg:grid-cols-12 gap-2">
         <Cell label="avg tok/s" value={t.avgTokPerSec.toFixed(1)} icon={Gauge} />
         <Cell label="max tok/s" value={t.maxTokPerSec.toFixed(1)} icon={Gauge} />
         <Cell label="p50 dur" value={fmtMs(t.p50DurationMs)} icon={Timer} />
         <Cell label="p95 dur" value={fmtMs(t.p95DurationMs)} icon={Timer} />
         <Cell label="cache" value={`${(t.cacheHitRate * 100).toFixed(0)}%`} icon={Layers} />
-        <Cell label="err rate" value={`${(t.errorRate * 100).toFixed(0)}%`} icon={AlertTriangle} />
+        <Cell label="err rate" value={`${(t.errorRate * 100).toFixed(0)}%`} icon={AlertTriangle} tone={t.errorRate > 0 ? "warn" : undefined} />
+        <Cell label="forbidden" value={`${(t.forbiddenViolationRate * 100).toFixed(0)}%`} icon={Bug} tone={t.forbiddenViolationRate > 0 ? "warn" : undefined} />
+        <Cell label="fails safe" value={`${(t.failsSafelyRate * 100).toFixed(0)}%`} icon={t.failsSafelyRate >= 0.9 ? ShieldCheck : Shield} tone={t.failsSafelyRate >= 0.9 ? "ok" : undefined} />
+        <Cell label="cheapest" value={`$${t.cheapestPassUsd.toFixed(4)}`} icon={DollarSign} />
         <Cell label="avg turns" value={t.avgTurns.toFixed(1)} icon={Hash} />
         <Cell label="tool calls" value={String(t.totalToolCalls)} icon={Wrench} />
         <Cell label="top tool" value={t.topTools[0]?.name ?? "—"} icon={Wrench} small />
@@ -49,13 +53,17 @@ export default function TelemetryStrip({ runId }: { runId: string }) {
   );
 }
 
-function Cell({ label, value, icon: Icon, small }: { label: string; value: string; icon: any; small?: boolean }) {
+function Cell({
+  label, value, icon: Icon, small, tone,
+}: {
+  label: string; value: string; icon: any; small?: boolean; tone?: "warn" | "ok";
+}) {
   return (
     <div className="px-2 py-1.5 rounded bg-bg-elev/50">
       <div className="flex items-center gap-1 text-[9px] uppercase tracking-wider text-fg-muted">
         <Icon className="size-2.5" /> {label}
       </div>
-      <div className={`mono ${small ? "text-[11px] truncate" : "text-sm"} font-medium mt-0.5`}>{value}</div>
+      <div className={clsx("mono font-medium mt-0.5", small ? "text-[11px] truncate" : "text-sm", tone === "warn" && "text-warn", tone === "ok" && "text-ok")}>{value}</div>
     </div>
   );
 }

--- a/state.yaml
+++ b/state.yaml
@@ -6,6 +6,7 @@ notes:
   - "Review is focused on harness correctness, grader trust, and desktop operator UI."
   - "GLM 5.2 should be treated as vision-input blind but strong at visual-code output such as SVG, Three.js, web UI, and app UI."
   - "Private GitHub repo created at RasputinKaiser/NEval."
+  - "Telemetry strip surfaces errorRate, forbiddenViolationRate, failsSafelyRate, and cheapestPassUsd"
 receipts:
   - "initial browser review found compare turns delta, nav highlighting, hydration warning, and mobile-only layout issues"
   - "npm run lint passed"


### PR DESCRIPTION
- TelemetryStrip now shows error rate, forbidden-violation rate, fails-safely rate, and cheapest pass cost.
- RunDetailClient case rows display per-case tok/s and cost.
- Add Debug toggle to reveal full grader stdout/file output.
- Record surfaced metrics in state.yaml audit notes.

Verification:
- npm run typecheck
- npm run lint
- npm run dev smoke-tested (`/runs` returns 200; telemetry API returns new stats)