### PR TITLE
Add visual previews + harden visual-code oracle bad scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist
 .env.local
 .codex/
 data/
-runs/
+data/runs/
 fixtures/**/node_modules
 fixtures/**/.git
 fixtures/.DS_Store

--- a/app/api/runs/[id]/case/[caseId]/artifact/route.ts
+++ b/app/api/runs/[id]/case/[caseId]/artifact/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "node:fs";
+import path from "node:path";
+import { getRunCase } from "@/lib/db";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string; caseId: string } }
+) {
+  const { id: runId, caseId } = params;
+  const artifactPath = req.nextUrl.searchParams.get("path");
+
+  if (!artifactPath) {
+    return NextResponse.json({ error: "Missing path parameter" }, { status: 400 });
+  }
+
+  // Sanitize: only allow filenames, no directory traversal
+  const safeName = path.basename(artifactPath);
+  if (safeName !== artifactPath) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  const rc = getRunCase(caseId);
+  if (!rc || rc.run_id !== runId) {
+    return NextResponse.json({ error: "Case not found" }, { status: 404 });
+  }
+
+  const fullPath = path.join(rc.workdir_path, safeName);
+  if (!fullPath.startsWith(rc.workdir_path)) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  try {
+    const content = fs.readFileSync(fullPath, "utf8");
+    return NextResponse.json({ path: safeName, content });
+  } catch {
+    return NextResponse.json(
+      { error: "Artifact not found. Run the case or oracle solve script first." },
+      { status: 404 }
+    );
+  }
+}

--- a/cases/reasoning/oracle/reasoning-counterfactual-plan-bad.sh
+++ b/cases/reasoning/oracle/reasoning-counterfactual-plan-bad.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF'
+Restart the service to see if the failure clears. Then check the database and call the payment API provider to ask if they are having issues. Notify the team once service is back up.
+EOF

--- a/cases/reasoning/oracle/reasoning-counterfactual-plan.sh
+++ b/cases/reasoning/oracle/reasoning-counterfactual-plan.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF'
+1. Roll back the deployment immediately to the last known-good production version so the service is restored while limiting blast radius.
+2. Inspect CI logs, application logs, database connection metrics, and payment API response times to identify whether the failure is in the app layer, database, or external dependency.
+3. Reproduce the failure in staging, apply a targeted fix (e.g., connection pool tuning, API timeout handling, or schema migration), and redeploy only after the fix passes automated health checks.
+EOF

--- a/cases/reasoning/oracle/reasoning-edge-case-explanation-bad.sh
+++ b/cases/reasoning/oracle/reasoning-edge-case-explanation-bad.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF'
+The bug is variable shadowing caused by the destructuring assignment. The temporary value of `a` is lost before it can be added, so the sequence uses stale data. The fix is to avoid destructuring by introducing a temporary variable.
+
+```javascript
+function fib(n) {
+  if (n <= 1) return n;
+  let a = 0, b = 1;
+  for (let i = 2; i < n; i++) {
+    let c = a + b;
+    a = b;
+    b = c;
+  }
+  return b;
+}
+```
+EOF

--- a/cases/reasoning/oracle/reasoning-edge-case-explanation.sh
+++ b/cases/reasoning/oracle/reasoning-edge-case-explanation.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF'
+The bug is an off-by-one error in the loop bound. The loop `for (let i = 2; i < n; i++)` stops when `i` reaches `n - 1`, so the last iteration that combines `a` and `b` uses index `n - 1` instead of `n`. This makes `fib(n)` return the (n - 1)th Fibonacci number. The fix is to change `< n` to `<= n` so the loop runs one more time.
+
+```javascript
+function fib(n) {
+  if (n <= 1) return n;
+  let a = 0, b = 1;
+  for (let i = 2; i <= n; i++) {
+    [a, b] = [b, a + b];
+  }
+  return b;
+}
+```
+EOF

--- a/cases/reasoning/oracle/reasoning-math-proof-sketch-bad.sh
+++ b/cases/reasoning/oracle/reasoning-math-proof-sketch-bad.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF'
+The sum grows like n^2/2 because each term is about n on average. By inspecting small cases, the closed form is n^2/2 + 1.
+EOF

--- a/cases/reasoning/oracle/reasoning-math-proof-sketch.sh
+++ b/cases/reasoning/oracle/reasoning-math-proof-sketch.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF'
+Let S = 1 + 2 + 3 + ... + n. Write the sum forwards and backwards:
+S = 1 + 2 + ... + (n-1) + n
+S = n + (n-1) + ... + 2 + 1
+Adding the two equations term by term gives 2S = (n+1) + (n+1) + ... + (n+1), with n copies of (n+1). Therefore 2S = n(n+1), and dividing by 2 yields S = n(n+1)/2.
+EOF

--- a/cases/reasoning/reasoning-counterfactual-plan.case.json
+++ b/cases/reasoning/reasoning-counterfactual-plan.case.json
@@ -1,0 +1,25 @@
+{
+  "id": "reasoning-counterfactual-plan",
+  "difficulty": "medium",
+  "category": "reasoning",
+  "name": "Produce a 3-step remediation plan",
+  "description": "Agent gets a failing deployment scenario and must emit a numbered 3-step remediation plan. Backstop regex checks for three numbered steps.",
+  "tags": ["planning", "counterfactual"],
+  "prompt": "A CI deployment failed because a new service failed health checks after launch. The service depends on a Postgres database and an external payment API. The previous production version was healthy. Produce a concise 3-step remediation plan to restore service quickly and safely.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 5, "timeout_seconds": 180, "permission_mode": "bypassPermissions" },
+  "budget": { "max_cost_usd": 0.5 },
+  "oracle": {
+    "solve": "oracle/reasoning-counterfactual-plan.sh",
+    "final_text": "1. Roll back the deployment immediately to the last known-good production version so the service is restored while limiting blast radius.\n2. Inspect CI logs, application logs, database connection metrics, and payment API response times to identify whether the failure is in the app layer, database, or external dependency.\n3. Reproduce the failure in staging, apply a targeted fix (e.g., connection pool tuning, API timeout handling, or schema migration), and redeploy only after the fix passes automated health checks.",
+    "known_bad": ["oracle/reasoning-counterfactual-plan-bad.sh"],
+    "known_bad_final_text": ["Restart the service to see if the failure clears. Then check the database and call the payment API provider to ask if they are having issues. Notify the team once service is back up."]
+  },
+  "graders": [
+    { "type": "rubric_llm", "model": "glm-5.2", "rubric": "The plan must have exactly three clearly numbered steps, must start by rolling back to the last known-good version, then diagnose logs/metrics, then apply a fix safely. Score 0-1 for ordering and correctness.", "min_score": 0.7 },
+    { "type": "regex_match", "pattern": "1\\.", "source": "final_text" },
+    { "type": "regex_match", "pattern": "2\\.", "source": "final_text" },
+    { "type": "regex_match", "pattern": "3\\.", "source": "final_text" }
+  ],
+  "pass_threshold": 1
+}

--- a/cases/reasoning/reasoning-edge-case-explanation.case.json
+++ b/cases/reasoning/reasoning-edge-case-explanation.case.json
@@ -1,0 +1,24 @@
+{
+  "id": "reasoning-edge-case-explanation",
+  "difficulty": "medium",
+  "category": "reasoning",
+  "name": "Explain an off-by-one bug and fix it",
+  "description": "Agent must explain an off-by-one bug in a loop and provide a corrected version. Backstop regex checks for the fixed loop bound.",
+  "tags": ["explanation", "bug", "edge-case"],
+  "prompt": "Consider this JavaScript snippet that is supposed to return the nth Fibonacci number (0-indexed: fib(0)=0, fib(1)=1):\n\nfunction fib(n) {\n  if (n <= 1) return n;\n  let a = 0, b = 1;\n  for (let i = 2; i < n; i++) {\n    [a, b] = [b, a + b];\n  }\n  return b;\n}\n\nIt has an off-by-one bug. Explain what the bug is and how to fix it, then give the corrected function. Answer in a short paragraph followed by the corrected code.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 5, "timeout_seconds": 180, "permission_mode": "bypassPermissions" },
+  "budget": { "max_cost_usd": 0.5 },
+  "oracle": {
+    "solve": "oracle/reasoning-edge-case-explanation.sh",
+    "final_text": "The bug is an off-by-one error in the loop bound. The loop `for (let i = 2; i < n; i++)` stops when `i` reaches `n - 1`, so the last iteration that combines `a` and `b` uses index `n - 1` instead of `n`. This makes `fib(n)` return the (n - 1)th Fibonacci number. The fix is to change `< n` to `<= n` so the loop runs one more time.\n\n```javascript\nfunction fib(n) {\n  if (n <= 1) return n;\n  let a = 0, b = 1;\n  for (let i = 2; i <= n; i++) {\n    [a, b] = [b, a + b];\n  }\n  return b;\n}\n```",
+    "known_bad": ["oracle/reasoning-edge-case-explanation-bad.sh"],
+    "known_bad_final_text": ["The bug is variable shadowing caused by the destructuring assignment. The temporary value of `a` is lost before it can be added, so the sequence uses stale data. The fix is to avoid destructuring by introducing a temporary variable.\n\n```javascript\nfunction fib(n) {\n  if (n <= 1) return n;\n  let a = 0, b = 1;\n  for (let i = 2; i < n; i++) {\n    let c = a + b;\n    a = b;\n    b = c;\n  }\n  return b;\n}\n```"]
+  },
+  "graders": [
+    { "type": "rubric_llm", "model": "glm-5.2", "rubric": "The explanation must identify that the loop stops one iteration too early because `i < n` should be `i <= n`, so the function returns the (n-1)th Fibonacci number instead of the nth. The corrected code must change the loop bound to `i <= n` (or equivalent). Score 0-1.", "min_score": 0.7 },
+    { "type": "regex_match", "pattern": "i\\s*<=\\s*n", "source": "final_text" },
+    { "type": "regex_match", "pattern": "off[- ]by[- ]one|one iteration too early|loop bound", "source": "final_text" }
+  ],
+  "pass_threshold": 1
+}

--- a/cases/reasoning/reasoning-math-proof-sketch.case.json
+++ b/cases/reasoning/reasoning-math-proof-sketch.case.json
@@ -1,0 +1,47 @@
+{
+  "id": "reasoning-math-proof-sketch",
+  "difficulty": "medium",
+  "category": "reasoning",
+  "name": "Sketch a proof for sum of first n integers",
+  "description": "Agent must give an informal proof that 1+2+...+n equals n(n+1)/2. Backstop regex checks for the closed form.",
+  "tags": [
+    "math",
+    "proof"
+  ],
+  "prompt": "Give a short informal proof that the sum 1 + 2 + 3 + ... + n equals a simple closed-form expression. State the formula and briefly explain why it holds.",
+  "setup": {
+    "type": "none"
+  },
+  "runner": {
+    "max_turns": 5,
+    "timeout_seconds": 180,
+    "permission_mode": "bypassPermissions"
+  },
+  "budget": {
+    "max_cost_usd": 0.5
+  },
+  "oracle": {
+    "solve": "oracle/reasoning-math-proof-sketch.sh",
+    "final_text": "Let S = 1 + 2 + 3 + ... + n. Write the sum forwards and backwards:\nS = 1 + 2 + ... + (n-1) + n\nS = n + (n-1) + ... + 2 + 1\nAdding the two equations term by term gives 2S = (n+1) + (n+1) + ... + (n+1), with n copies of (n+1). Therefore 2S = n(n+1), and dividing by 2 yields S = n(n+1)/2.",
+    "known_bad": [
+      "oracle/reasoning-math-proof-sketch-bad.sh"
+    ],
+    "known_bad_final_text": [
+      "The sum grows like n^2/2 because each term is about n on average. By inspecting small cases, the closed form is n^2/2 + 1."
+    ]
+  },
+  "graders": [
+    {
+      "type": "rubric_llm",
+      "model": "glm-5.2[1m]",
+      "rubric": "The answer must state the formula n(n+1)/2, explain the pairing argument or induction approach, and conclude with the closed form. Score 0-1.",
+      "min_score": 0.7
+    },
+    {
+      "type": "regex_match",
+      "pattern": "(?:n\\s*\\(\\s*n\\s*\\+\\s*1\\s*\\)\\s*/\\s*2|\\\\frac\\s*\\{\\s*n\\s*\\(\\s*n\\s*\\+\\s*1\\s*\\)\\s*\\}\\s*\\{\\s*2\\s*\\})",
+      "source": "final_text"
+    }
+  ],
+  "pass_threshold": 1
+}

--- a/cases/visual-code/oracle/visual-svg-status-card-bad.sh
+++ b/cases/visual-code/oracle/visual-svg-status-card-bad.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > status-card.svg <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <title>NEval Accuracy Run status card</title>
+  <rect width="800" height="500" rx="28" fill="#0b0d12"/>
+  <rect x="48" y="44" width="704" height="412" rx="24" fill="#141821" stroke="#2f3545"/>
+  <text x="84" y="104" fill="#f4f7fb" font-size="34" font-family="Inter, sans-serif">NEval Accuracy Run</text>
+  <text x="84" y="154" fill="#9aa4b2" font-size="18" font-family="Inter, sans-serif">Pass rate</text>
+  <text x="84" y="202" fill="#7ee787" font-size="52" font-family="Inter, sans-serif">92%</text>
+  <text x="342" y="154" fill="#9aa4b2" font-size="18" font-family="Inter, sans-serif">Bad probes caught</text>
+  <text x="600" y="154" fill="#9aa4b2" font-size="18" font-family="Inter, sans-serif">VC</text>
+  <rect x="92" y="330" width="52" height="54" rx="8" fill="#7c5cff"/>
+  <rect x="166" y="292" width="52" height="92" rx="8" fill="#56d4dd"/>
+  <rect x="240" y="254" width="52" height="130" rx="8" fill="#7ee787"/>
+  <rect x="314" y="276" width="52" height="108" rx="8" fill="#ffd166"/>
+  <path d="M430 370 C475 280, 520 310, 568 242 S662 258, 712 190" fill="none" stroke="#f778ba" stroke-width="8" stroke-linecap="round"/>
+</svg>
+SVG

--- a/cases/visual-code/oracle/visual-svg-status-card.sh
+++ b/cases/visual-code/oracle/visual-svg-status-card.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > status-card.svg <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" role="img" aria-labelledby="title desc">
+  <title>NEval Accuracy Run status card</title>
+  <desc>Dark evaluation status card showing pass rate, known-bad rejection coverage, and visual-code artifact checks.</desc>
+  <rect width="800" height="500" rx="28" fill="#0b0d12"/>
+  <rect x="48" y="44" width="704" height="412" rx="24" fill="#141821" stroke="#2f3545"/>
+  <text x="84" y="104" fill="#f4f7fb" font-size="34" font-family="Inter, sans-serif">NEval Accuracy Run</text>
+  <text x="84" y="154" fill="#9aa4b2" font-size="18" font-family="Inter, sans-serif">Pass rate</text>
+  <text x="84" y="202" fill="#7ee787" font-size="52" font-family="Inter, sans-serif">92%</text>
+  <text x="342" y="154" fill="#9aa4b2" font-size="18" font-family="Inter, sans-serif">Known-bad rejected</text>
+  <text x="342" y="202" fill="#ffd166" font-size="52" font-family="Inter, sans-serif">8/8</text>
+  <text x="600" y="154" fill="#9aa4b2" font-size="18" font-family="Inter, sans-serif">Visual-code</text>
+  <text x="600" y="202" fill="#79c0ff" font-size="52" font-family="Inter, sans-serif">2</text>
+  <rect x="92" y="330" width="52" height="54" rx="8" fill="#7c5cff"/>
+  <rect x="166" y="292" width="52" height="92" rx="8" fill="#56d4dd"/>
+  <rect x="240" y="254" width="52" height="130" rx="8" fill="#7ee787"/>
+  <rect x="314" y="276" width="52" height="108" rx="8" fill="#ffd166"/>
+  <path d="M430 370 C475 280, 520 310, 568 242 S662 258, 712 190" fill="none" stroke="#f778ba" stroke-width="8" stroke-linecap="round"/>
+  <text x="92" y="420" fill="#9aa4b2" font-size="15" font-family="Inter, sans-serif">deterministic</text>
+  <text x="430" y="420" fill="#9aa4b2" font-size="15" font-family="Inter, sans-serif">trend line</text>
+</svg>
+SVG

--- a/cases/visual-code/oracle/visual-web-eval-dashboard-bad.sh
+++ b/cases/visual-code/oracle/visual-web-eval-dashboard-bad.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > index.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NEval Run Report</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main data-testid="eval-dashboard" class="shell" style="display:flex;flex-direction:column;padding:2rem;">
+      <header class="masthead">
+        <h1>NEval Run Report</h1>
+        <p>Automated evaluation dashboard</p>
+      </header>
+      <section class="metrics" style="display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;">
+        <div data-testid="metric-card" class="card">
+          <span class="label">Pass@1</span>
+          <span class="value">87%</span>
+        </div>
+        <div data-testid="metric-card" class="card">
+          <span class="label">Pass@k</span>
+          <span class="value">93%</span>
+        </div>
+        <div data-testid="metric-card" class="card">
+          <span class="label">Visual-code</span>
+          <span class="value">2</span>
+        </div>
+      </section>
+      <section class="chart-area" style="display:flex;align-items:center;justify-content:center;height:200px;">
+        <div class="placeholder">Chart area — pass distribution</div>
+      </section>
+    </main>
+  </body>
+</html>
+HTML
+cat > styles.css <<'CSS'
+body { margin: 0; font-family: Inter, sans-serif; background: #0b0d12; color: #f4f7fb; }
+.shell { max-width: 960px; margin: 0 auto; }
+.masthead h1 { font-size: 1.5rem; }
+.card { border: 1px solid #2f3545; border-radius: 8px; padding: 1rem; }
+.label { font-size: 0.75rem; color: #9aa4b2; }
+.value { font-size: 1.5rem; font-weight: 600; }
+.placeholder { color: #57606a; }
+CSS

--- a/cases/visual-code/oracle/visual-web-eval-dashboard.sh
+++ b/cases/visual-code/oracle/visual-web-eval-dashboard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > index.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NEval Run Report</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main data-testid="eval-dashboard" class="shell">
+      <header class="masthead">
+        <h1>NEval Run Report</h1>
+        <p>Deterministic evidence, known-bad rejection, and visual-code quality in one operator view.</p>
+      </header>
+      <section class="metrics" aria-label="run metrics">
+        <article data-testid="metric-card"><span>Pass@1</span><strong>87%</strong></article>
+        <article data-testid="metric-card"><span>Pass@k</span><strong>94%</strong></article>
+        <article data-testid="metric-card"><span>Known-bad</span><strong>rejected</strong></article>
+        <article data-testid="metric-card"><span>Visual-code</span><strong>2 cases</strong></article>
+      </section>
+      <svg data-testid="pass-chart" viewBox="0 0 640 180" role="img" aria-label="Pass rate trend chart">
+        <rect x="0" y="0" width="640" height="180" rx="18" fill="#111827"></rect>
+        <path d="M52 132 C140 84, 200 116, 288 72 S456 56, 588 34" fill="none" stroke="#7c5cff" stroke-width="8"></path>
+        <rect x="52" y="100" width="36" height="42" fill="#56d4dd"></rect>
+        <rect x="122" y="82" width="36" height="60" fill="#56d4dd"></rect>
+        <rect x="192" y="64" width="36" height="78" fill="#56d4dd"></rect>
+      </svg>
+      <table data-testid="case-table">
+        <thead><tr><th>Case</th><th>Evidence</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr><td>visual-svg-status-card</td><td>artifact contract</td><td>passed</td></tr>
+          <tr><td>swe-pipeline-multi-fix</td><td>tests + diff</td><td>passed</td></tr>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>
+HTML
+cat > styles.css <<'CSS'
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: #080a0f;
+  color: #edf2f7;
+}
+body { margin: 0; min-height: 100vh; background: #080a0f; }
+.shell { width: min(1120px, calc(100vw - 64px)); margin: 40px auto; display: grid; gap: 24px; }
+.masthead { display: flex; align-items: end; justify-content: space-between; gap: 32px; }
+.masthead h1 { margin: 0; font-size: 44px; letter-spacing: 0; }
+.masthead p { margin: 0; max-width: 520px; color: #9aa4b2; line-height: 1.5; }
+.metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
+[data-testid="metric-card"] { border: 1px solid #273142; background: #111827; padding: 20px; border-radius: 8px; }
+[data-testid="metric-card"] span { display: block; color: #9aa4b2; margin-bottom: 12px; }
+[data-testid="metric-card"] strong { display: block; font-size: 28px; }
+[data-testid="pass-chart"] { width: 100%; height: 220px; }
+table { width: 100%; border-collapse: collapse; overflow: hidden; border-radius: 8px; }
+th, td { text-align: left; padding: 15px 18px; border-bottom: 1px solid #273142; }
+th { color: #9aa4b2; font-weight: 600; background: #10151f; }
+td { background: #0f141d; }
+CSS

--- a/cases/visual-code/visual-svg-status-card.case.json
+++ b/cases/visual-code/visual-svg-status-card.case.json
@@ -1,0 +1,36 @@
+{
+  "id": "visual-svg-status-card",
+  "category": "visual-code",
+  "difficulty": "medium",
+  "name": "Generate a polished SVG status card",
+  "description": "Visual-code task for blind-but-design-capable models: create a single SVG artifact with a structured status card, labeled chart, legend, and accessible title/description. Grading stays deterministic by checking the generated SVG contract.",
+  "tags": ["visual-code", "svg", "design", "accessibility"],
+  "split": "public",
+  "prompt": "Create a file named status-card.svg. It must be a self-contained SVG with viewBox=\"0 0 800 500\". The design should be a polished dark status card for an agent eval run named \"NEval Accuracy Run\". Include an accessible <title> and <desc>, visible text for \"NEval Accuracy Run\", \"Pass rate\", \"Known-bad rejected\", and \"Visual-code\". Include at least one chart-like element using <rect> bars and one <path> trend line. Do not create any other files.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 12, "timeout_seconds": 180, "permission_mode": "bypassPermissions" },
+  "budget": { "max_turns": 12, "max_cost_usd": 0.5 },
+  "visual": {
+    "kind": "svg",
+    "requires_vision_input": false,
+    "expected_artifacts": ["status-card.svg"]
+  },
+  "graders": [
+    { "type": "file_exists", "path": "status-card.svg", "weight": 10 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "<svg[^>]+viewBox=[\"']0 0 800 500[\"']", "weight": 15 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "<title>[^<]*NEval Accuracy Run[^<]*</title>", "weight": 15 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "<desc>[^<]{30,}</desc>", "weight": 10 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "Pass rate", "weight": 10 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "Known-bad rejected", "weight": 10 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "Visual-code", "weight": 10 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "<rect\\b", "weight": 10 },
+    { "type": "file_contains", "path": "status-card.svg", "pattern": "<path\\b", "weight": 10 },
+    { "type": "file_exists", "path": "index.html", "negate": true, "weight": 5, "forbidden": true }
+  ],
+  "pass_threshold": 0.9,
+  "oracle": {
+    "solve": "oracle/visual-svg-status-card.sh",
+    "noop_max_score": 0.1,
+    "known_bad": ["oracle/visual-svg-status-card-bad.sh"]
+  }
+}

--- a/cases/visual-code/visual-web-eval-dashboard.case.json
+++ b/cases/visual-code/visual-web-eval-dashboard.case.json
@@ -1,0 +1,37 @@
+{
+  "id": "visual-web-eval-dashboard",
+  "category": "visual-code",
+  "difficulty": "hard",
+  "name": "Build a static eval results dashboard",
+  "description": "Visual-code task: produce a small desktop web UI artifact with semantic sections, metric cards, case table, and an inline SVG chart. This tests UI-generation quality without requiring image input.",
+  "tags": ["visual-code", "web-ui", "dashboard", "html", "css"],
+  "split": "public",
+  "prompt": "Create two files: index.html and styles.css. Build a polished desktop-first static dashboard for an agent evaluation run. The page must include a root element with data-testid=\"eval-dashboard\", an h1 containing \"NEval Run Report\", four metric cards with data-testid=\"metric-card\", a case table with data-testid=\"case-table\", and an inline SVG chart with data-testid=\"pass-chart\". Include visible labels for \"Pass@1\", \"Pass@k\", \"Known-bad\", and \"Visual-code\". Use CSS grid or flex layout in styles.css. Do not use external assets, scripts, or network imports.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 18, "timeout_seconds": 240, "permission_mode": "bypassPermissions" },
+  "budget": { "max_turns": 18, "max_cost_usd": 0.75 },
+  "visual": {
+    "kind": "web_ui",
+    "requires_vision_input": false,
+    "expected_artifacts": ["index.html", "styles.css"]
+  },
+  "graders": [
+    { "type": "file_exists", "path": "index.html", "weight": 10 },
+    { "type": "file_exists", "path": "styles.css", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "data-testid=[\"']eval-dashboard[\"']", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "NEval Run Report", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "data-testid=[\"']metric-card[\"']", "weight": 10 },
+    { "type": "exit_code", "command": "node -e \"const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const n=(html.match(/data-testid=['\\\"]metric-card['\\\"]/g)||[]).length; if(n<4) process.exit(1)\"", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "data-testid=[\"']case-table[\"']", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "data-testid=[\"']pass-chart[\"']", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "Pass@1|Pass@k|Known-bad|Visual-code", "weight": 10 },
+    { "type": "file_contains", "path": "styles.css", "pattern": "grid|flex", "weight": 10 },
+    { "type": "file_contains", "path": "index.html", "pattern": "https?://|<script", "negate": true, "weight": 10, "forbidden": true }
+  ],
+  "pass_threshold": 0.9,
+  "oracle": {
+    "solve": "oracle/visual-web-eval-dashboard.sh",
+    "noop_max_score": 0.1,
+    "known_bad": ["oracle/visual-web-eval-dashboard-bad.sh"]
+  }
+}

--- a/components/CaseDetailClient.tsx
+++ b/components/CaseDetailClient.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import {
   ChevronRight, ChevronDown, Hash, Wrench, Terminal, FileText,
   CornerDownRight, Clock, User, Cpu, DollarSign, AlertTriangle, CheckCircle2, XCircle,
+  Eye, FileCode,
 } from "lucide-react";
 import type { RunCaseRecord, RunnerResult } from "@/lib/types";
 
@@ -15,6 +16,9 @@ export default function CaseDetailClient({ caseId, runId, initial }: Props) {
   const [rc, setRc] = useState<RunCaseRecord | null>(initial);
   const [openTools, setOpenTools] = useState(true);
   const [openTranscript, setOpenTranscript] = useState(true);
+  const [openPreview, setOpenPreview] = useState(true);
+  const [previewContent, setPreviewContent] = useState<{ path: string; content: string; kind: "svg" | "html" } | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const lastEnd = useRef(initial?.ended_at ?? 0);
 
   useEffect(() => {
@@ -45,6 +49,32 @@ export default function CaseDetailClient({ caseId, runId, initial }: Props) {
 
   if (!rc) return <div className="p-8 text-fg-muted">Loading…</div>;
 
+  async function loadPreview(artifactPath: string) {
+    setPreviewLoading(true);
+    setPreviewContent(null);
+    try {
+      const res = await fetch(`/api/runs/${runId}/case/${caseId}/artifact?path=${encodeURIComponent(artifactPath)}`);
+      if (!res.ok) {
+        setPreviewContent(null);
+        return;
+      }
+      const data = await res.json();
+      if (data.content) {
+        const isSvg = artifactPath.endsWith(".svg");
+        const isHtml = artifactPath.endsWith(".html") || artifactPath.endsWith(".htm");
+        setPreviewContent({
+          path: artifactPath,
+          content: data.content,
+          kind: isSvg ? "svg" : isHtml ? "html" : "svg",
+        });
+      }
+    } catch {
+      // Artifact not available yet
+    } finally {
+      setPreviewLoading(false);
+    }
+  }
+
   const runner = rc.runner_result;
   const grader = rc.grader_result;
 
@@ -72,6 +102,50 @@ export default function CaseDetailClient({ caseId, runId, initial }: Props) {
       {openTranscript && runner && (
         <Section title="Transcript" icon={Terminal} count={runner.transcript.length} open={openTranscript} onToggle={() => setOpenTranscript(!openTranscript)}>
           <Transcript runner={runner} />
+        </Section>
+      )}
+
+      {rc.case_def?.visual?.expected_artifacts?.length && (
+        <Section title="Visual preview" icon={Eye} count={rc.case_def.visual.expected_artifacts.length} open={openPreview} onToggle={() => setOpenPreview(!openPreview)}>
+          <div className="px-4 py-3 space-y-3">
+            <div className="flex flex-wrap gap-2">
+              {rc.case_def.visual.expected_artifacts.map((art) => (
+                <button
+                  key={art}
+                  onClick={() => loadPreview(art)}
+                  className={clsx(
+                    "text-xs mono px-2 py-1 rounded border transition-colors",
+                    previewContent?.path === art
+                      ? "border-accent-soft text-accent-soft bg-accent-soft/10"
+                      : "border-bd-subtle text-fg-muted hover:text-fg hover:border-fg-dim"
+                  )}
+                >
+                  <FileCode className="size-3 inline mr-1" />
+                  {art}
+                </button>
+              ))}
+            </div>
+            {previewLoading && <div className="text-xs text-fg-muted">Loading artifact…</div>}
+            {previewContent && previewContent.kind === "svg" && (
+              <div className="rounded-lg border border-bd-subtle overflow-hidden bg-white p-4">
+                <div dangerouslySetInnerHTML={{ __html: previewContent.content }} />
+              </div>
+            )}
+            {previewContent && previewContent.kind === "html" && (
+              <iframe
+                sandbox=""
+                srcDoc={previewContent.content}
+                className="w-full rounded-lg border border-bd-subtle"
+                style={{ minHeight: "400px", background: "#fff" }}
+                title="Preview"
+              />
+            )}
+            {!previewContent && !previewLoading && (
+              <div className="text-xs text-fg-muted">
+                Click an artifact filename to render it inline. Artifacts are read from the run workdir after the case has been executed or the oracle solve script has been run.
+              </div>
+            )}
+          </div>
         </Section>
       )}
 


### PR DESCRIPTION
## Changes

### Visual preview section (components/CaseDetailClient.tsx)
- New collapsible 'Visual preview' section on the case detail page
- Renders SVG artifacts inline (dangerouslySetInnerHTML)
- Renders HTML artifacts in a sandboxed iframe (sandbox='""')
- Fetches artifact content via new API endpoint
- Shows expected artifact filenames as clickable chips

### Artifact API route (app/api/runs/[id]/case/[caseId]/artifact/route.ts)
- New GET endpoint that reads artifact files from the run workdir
- Path sanitization (basename only, no directory traversal)
- Returns 404 with helpful message if artifact not yet generated

### Hardened bad oracle scripts
- visual-svg-status-card-bad.sh: now produces a plausible-looking SVG
  card that's missing `<desc>`, 'Known-bad rejected', and 'Visual-code'
  text — exercising more graders than the old minimal stub
- visual-web-eval-dashboard-bad.sh: now produces a plausible-looking
  dashboard with metric-cards and grid layout but missing case-table,
  pass-chart, and 'Known-bad' — more subtle than the old bare HTML stub

### Other
- Fix .gitignore: `runs/` was matching app/api/runs/ (matched at any
  level). Narrowed to `data/runs/` so Next.js API routes aren't ignored.
- Track visual-code case files and oracle scripts (they were untracked)

### Verification
- `npm run typecheck` passes
- All four oracle scripts produce valid output when run from a temp dir
- Bad SVG variant correctly lacks `<desc>`, 'Known-bad rejected', and
  'Visual-code' text (confirmed via grep)