### PR TITLE
Improve run detail UX: errors, grader diffs, transcript, re-run links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,16 @@ dist
 .codex/
 data/
 runs/
+!app/runs/
+!app/runs/**
+!app/api/runs/
+!app/api/runs/**
+!app/runs/
+!app/runs/
+!app/runs/**
+!app/api/runs/
+!app/api/runs/**
+!app/runs/**
 fixtures/**/node_modules
 fixtures/**/.git
 fixtures/.DS_Store

--- a/app/api/runs/[id]/route.ts
+++ b/app/api/runs/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getRun, listRunCases } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  const run = getRun(params.id);
+  if (!run) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+  const cases = listRunCases(params.id);
+  return NextResponse.json({ run, cases });
+}

--- a/app/api/runs/[id]/telemetry/route.ts
+++ b/app/api/runs/[id]/telemetry/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getRun, listRunCases } from "@/lib/db";
+import { computeTelemetry } from "@/lib/summary";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  const run = getRun(params.id);
+  if (!run) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+  const cases = listRunCases(params.id);
+  const telemetry = computeTelemetry(cases);
+  return NextResponse.json({ telemetry });
+}

--- a/app/runs/[id]/page.tsx
+++ b/app/runs/[id]/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { getRun, listRunCases } from "@/lib/db";
+import RunDetailClient from "@/components/RunDetailClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const run = getRun(params.id);
+  if (!run) notFound();
+  const cases = listRunCases(params.id);
+  return (
+    <main className="p-4 max-w-7xl mx-auto">
+      <RunDetailClient
+        runId={params.id}
+        initialCases={cases}
+        running={run.status === "running"}
+        model={run.params.model}
+      />
+    </main>
+  );
+}

--- a/app/runs/page.tsx
+++ b/app/runs/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { listRuns } from "@/lib/db";
+import StatusBadge from "@/components/StatusBadge";
+
+export const dynamic = "force-dynamic";
+
+
+export default async function Page() {
+  const runs = listRuns(50);
+  return (
+    <div className="p-8 max-w-6xl mx-auto">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Runs</h1>
+          <p className="text-sm text-fg-muted mt-1">Recent evaluation runs.</p>
+        </div>
+        <Link href="/runs/new" className="text-sm text-accent-soft hover:underline">New run</Link>
+      </header>
+      {runs.length === 0 ? (
+        <div className="card p-8 text-center text-sm text-fg-muted">
+          No runs yet. <Link href="/runs/new" className="text-accent-soft hover:underline">Start one</Link>.
+        </div>
+      ) : (
+        <div className="card overflow-hidden">
+          {runs.map((r) => (
+            <div key={r.id} className="px-4 py-3 border-b border-bd-subtle last:border-0 flex items-center justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <Link href={`/runs/${r.id}`} className="font-medium hover:text-accent-soft truncate block">{r.name}</Link>
+                <div className="text-[11px] text-fg-dim mono mt-0.5">
+                  {new Date(r.created_at).toLocaleString()} · {r.params.runner} · {r.params.parallel}×{r.params.samples && r.params.samples > 1 ? ` · ${r.params.samples} samples` : ""}
+                </div>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                {r.summary && (
+                  <span className={`text-sm mono font-semibold ${r.summary.passRate >= 1 ? "text-ok" : "text-err"}`}>
+                    {(r.summary.passRate * 100).toFixed(0)}%
+                  </span>
+                )}
+                <StatusBadge status={r.status} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/RunDetailClient.tsx
+++ b/components/RunDetailClient.tsx
@@ -6,13 +6,13 @@ import clsx from "clsx";
 import StatusBadge from "./StatusBadge";
 import TelemetryStrip from "./TelemetryStrip";
 import {
-  ChevronRight, Wrench, Clock, Hash, Cpu, DollarSign, Loader2, CircleDot, Gauge,
+  ChevronRight, Wrench, Clock, Hash, Cpu, DollarSign, Loader2, CircleDot, Gauge, AlertCircle, PlayCircle,
 } from "lucide-react";
-import type { RunCaseRecord } from "@/lib/types";
+import type { RunCaseRecord, GraderResult, TranscriptEntry } from "@/lib/types";
 
-interface Props { runId: string; initialCases: RunCaseRecord[]; running: boolean; }
+interface Props { runId: string; initialCases: RunCaseRecord[]; running: boolean; model?: string; }
 
-export default function RunDetailClient({ runId, initialCases, running }: Props) {
+export default function RunDetailClient({ runId, initialCases, running, model }: Props) {
   const [cases, setCases] = useState<RunCaseRecord[]>(initialCases);
   const [selectedIdx, setSelectedIdx] = useState<number | null>(initialCases.length ? 0 : null);
   const [live, setLive] = useState(running);
@@ -49,62 +49,73 @@ export default function RunDetailClient({ runId, initialCases, running }: Props)
       <TelemetryStrip runId={runId} />
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_1.4fr] gap-4">
         <section className="card overflow-hidden flex flex-col">
-        <div className="px-4 py-3 border-b border-bd flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Hash className="size-3.5 text-fg-muted" />
-            <span className="text-sm font-medium">Cases</span>
-            <span className="text-[10px] text-fg-dim mono px-1.5 py-0.5 rounded bg-bg-elev">{cases.length}</span>
+          <div className="px-4 py-3 border-b border-bd flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Hash className="size-3.5 text-fg-muted" />
+              <span className="text-sm font-medium">Cases</span>
+              <span className="text-[10px] text-fg-dim mono px-1.5 py-0.5 rounded bg-bg-elev">{cases.length}</span>
+            </div>
+            {live && <Loader2 className="size-3.5 text-accent-soft animate-spin" />}
           </div>
-          {live && <Loader2 className="size-3.5 text-accent-soft animate-spin" />}
-        </div>
 
-        <div className="px-4 py-2 border-b border-bd-subtle flex gap-3 text-[11px]">
-          <span className="text-ok"> {counts.passed}</span>
-          <span className="text-err"> {counts.failed}</span>
-          <span className="text-err">! {counts.error}</span>
-          {counts.running > 0 && <span className="text-accent-soft">◐ {counts.running}</span>}
-          {counts.pending > 0 && <span className="text-fg-dim">◌ {counts.pending}</span>}
-        </div>
+          <div className="px-4 py-2 border-b border-bd-subtle flex gap-3 text-[11px]">
+            <span className="text-ok">● {counts.passed}</span>
+            <span className="text-err">● {counts.failed}</span>
+            <span className="text-warn">! {counts.error}</span>
+            {counts.running > 0 && <span className="text-accent-soft">● {counts.running}</span>}
+            {counts.pending > 0 && <span className="text-fg-dim">● {counts.pending}</span>}
+          </div>
 
-        <div className="max-h-[calc(100vh-280px)] overflow-y-auto divide-y divide-bd-subtle">
-          {cases.map((c, i) => {
-            const sel = selectedIdx === i;
-            const runner = c.runner_result;
-            return (
-              <button
-                key={c.id}
-                onClick={() => setSelectedIdx(i)}
-                className={clsx(
-                  "w-full text-left px-3 py-2.5 flex items-center gap-3 transition-colors",
-                  sel ? "bg-accent/10" : "hover:bg-bg-elev"
-                )}
-              >
-                <span className="text-[10px] text-fg-dim mono w-6 shrink-0">{String(i + 1).padStart(2, "0")}</span>
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm truncate">{c.case_name}</div>
-                  <div className="text-[10px] text-fg-dim mono mt-0.5 flex items-center gap-1.5">
-                    <span className="px-1 rounded bg-bg-elev">{c.category}</span>
-                    {runner && <span>· turns {runner.numTurns} · {runner.toolCalls.length} tools</span>}
+          <div className="max-h-[calc(100vh-280px)] overflow-y-auto divide-y divide-bd-subtle">
+            {cases.map((c, i) => {
+              const sel = selectedIdx === i;
+              const runner = c.runner_result;
+              const rerunHref = `/runs/new?caseIds=${encodeURIComponent(c.case_id)}${model ? `&model=${encodeURIComponent(model)}` : ""}`;
+              return (
+                <div
+                  key={c.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setSelectedIdx(i)}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setSelectedIdx(i); }}
+                  className={clsx(
+                    "group w-full text-left px-3 py-2.5 flex items-center gap-3 transition-colors cursor-pointer",
+                    sel ? "bg-accent/10" : "hover:bg-bg-elev"
+                  )}
+                >
+                  <span className="text-[10px] text-fg-dim mono w-6 shrink-0">{String(i + 1).padStart(2, "0")}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm truncate">{c.case_name}</div>
+                    <div className="text-[10px] text-fg-dim mono mt-0.5 flex items-center gap-1.5">
+                      <span className="px-1 rounded bg-bg-elev">{c.category}</span>
+                      {runner && <span>· turns {runner.numTurns} · {runner.toolCalls.length} tools</span>}
+                    </div>
                   </div>
+                  <Link
+                    href={rerunHref}
+                    onClick={(e) => e.stopPropagation()}
+                    className="shrink-0 inline-flex items-center gap-1 text-[10px] text-accent-soft opacity-0 group-hover:opacity-100 transition-opacity hover:underline"
+                  >
+                    <PlayCircle className="size-3.5" /> Re-run
+                  </Link>
+                  <StatusBadge status={c.status} size="xs" />
                 </div>
-                <StatusBadge status={c.status} size="xs" />
-              </button>
-            );
-          })}
-        </div>
-      </section>
-
-      <section>
-        {selectedIdx === null || !cases[selectedIdx] ? (
-          <div className="card p-12 text-center">
-            <CircleDot className="size-8 text-fg-dim mx-auto mb-2" />
-            <div className="text-sm text-fg-muted">Select a case to view details</div>
-            <div className="text-[11px] text-fg-dim mt-1">Live transcript and grading results available after completion</div>
+              );
+            })}
           </div>
-        ) : (
-          <CaseSidePanel key={cases[selectedIdx].id} rc={cases[selectedIdx]} runId={runId} />
-        )}
-      </section>
+        </section>
+
+        <section>
+          {selectedIdx === null || !cases[selectedIdx] ? (
+            <div className="card p-12 text-center">
+              <CircleDot className="size-8 text-fg-dim mx-auto mb-2" />
+              <div className="text-sm text-fg-muted">Select a case to view details</div>
+              <div className="text-[11px] text-fg-dim mt-1">Live transcript and grading results available after completion</div>
+            </div>
+          ) : (
+            <CaseSidePanel key={cases[selectedIdx].id} rc={cases[selectedIdx]} runId={runId} />
+          )}
+        </section>
       </div>
     </div>
   );
@@ -125,6 +136,18 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
         </div>
       </div>
 
+      {(rc.status === "error" || rc.error_msg) && (
+        <div className="card p-4 border border-warn/30">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="size-4 text-warn shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium text-warn">Error</div>
+              <pre className="mt-2 text-xs mono text-warn whitespace-pre-wrap break-words">{rc.error_msg || "An error occurred while running this case."}</pre>
+            </div>
+          </div>
+        </div>
+      )}
+
       {runner && (
         <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
           <Mini label="Turns" value={String(runner.numTurns)} icon={Hash} />
@@ -132,7 +155,7 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
           <Mini label="tok/s" value={runner.durationMs > 0 ? (runner.usage.outputTokens / (runner.durationMs / 1000)).toFixed(1) : "0"} icon={Gauge} />
           <Mini label="Cost" value={`$${runner.usage.costUsd.toFixed(4)}`} icon={DollarSign} />
           <Mini label="Tokens ↑" value={runner.usage.inputTokens.toLocaleString()} icon={Cpu} />
-          <Mini label="Tokens ↓" value={runner.usage.outputTokens.toLocaleString()} icon={Cpu} />
+          <Mini label="Tokens" value={runner.usage.outputTokens.toLocaleString()} icon={Cpu} />
           <Mini label="Exit" value={String(runner.exitCode)} icon={Wrench} />
         </div>
       )}
@@ -147,21 +170,16 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
           </div>
           <div className="divide-y divide-bd-subtle">
             {grader.results.map((g, i) => (
-              <div key={i} className="px-4 py-2.5">
-                <div className="flex items-start gap-2">
-                  <span className={clsx("text-base leading-none", g.passed ? "text-ok" : "text-err")}>{g.passed ? "" : ""}</span>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="font-mono text-[11px] px-1.5 py-0.5 rounded bg-bg-elev">{g.spec.type}</span>
-                      <span className="text-[10px] text-fg-dim mono">{g.durationMs}ms</span>
-                    </div>
-                    <div className="text-[11px] text-fg-muted mt-1 break-words">{g.detail}</div>
-                    {g.output && <pre className="mt-1.5 text-[10px] mono text-fg-dim bg-bg p-2 rounded border border-bd-subtle overflow-x-auto max-h-40 overflow-y-auto">{g.output.slice(0, 2000)}</pre>}
-                  </div>
-                </div>
-              </div>
+              <GraderRow key={i} g={g} />
             ))}
           </div>
+        </div>
+      )}
+
+      {runner && runner.transcript.length > 0 && (
+        <div className="card overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-bd-subtle bg-bg-subtle/50 text-xs font-medium">Transcript ({runner.transcript.length})</div>
+          <Transcript transcript={runner.transcript} />
         </div>
       )}
 
@@ -178,7 +196,7 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
           <div className="divide-y divide-bd-subtle max-h-80 overflow-y-auto">
             {runner.toolCalls.map((tc, i) => (
               <details key={tc.id || i} className="group">
-                <summary className="px-4 py-2 cursor-pointer hover:bg-bg-elev flex items-center gap-2">
+                <summary className="px-4 py-2 cursor-pointer hover:bg-bg-elev flex items-center gap-2 list-none">
                   <ChevronRight className="size-3 text-fg-dim group-open:rotate-90 transition-transform" />
                   <span className="text-[10px] text-fg-dim mono w-6">{String(i + 1).padStart(2, "0")}</span>
                   <span className="text-xs font-mono">{tc.name}</span>
@@ -197,6 +215,129 @@ function CaseSidePanel({ rc, runId }: { rc: RunCaseRecord; runId: string }) {
       <div className="text-center">
         <Link href={`/runs/${runId}/case/${rc.case_id}`} className="text-xs text-accent-soft hover:underline">Open full transcript →</Link>
       </div>
+    </div>
+  );
+}
+
+function GraderRow({ g }: { g: GraderResult }) {
+  const summary = g.detail.length > 120 ? `${g.detail.slice(0, 120)}…` : g.detail;
+  const expected = g.spec.type === "file_eq" ? g.spec.expected : g.spec.type === "file_contains" ? g.spec.pattern : undefined;
+  const actual = g.output ?? "";
+  const showDiff = (g.spec.type === "file_eq" || g.spec.type === "file_contains") && !g.passed && actual;
+
+  return (
+    <details className="group">
+      <summary className="px-4 py-2.5 cursor-pointer hover:bg-bg-elev flex items-start gap-2 list-none">
+        <ChevronRight className="size-3.5 text-fg-dim mt-0.5 group-open:rotate-90 transition-transform" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-[11px] px-1.5 py-0.5 rounded bg-bg-elev">{g.spec.type}</span>
+            <span className={clsx("text-[10px] px-1.5 py-0.5 rounded-full border", g.passed ? "text-ok border-ok/30 bg-ok/10" : "text-err border-err/30 bg-err/10")}>
+              {g.passed ? "passed" : "failed"}
+            </span>
+            <span className="text-[10px] text-fg-dim mono">{g.durationMs}ms</span>
+          </div>
+          <div className={clsx("text-[11px] mt-1 break-words", g.passed ? "text-fg-muted" : "text-fg")}>{summary}</div>
+        </div>
+      </summary>
+      <div className="px-4 py-3 space-y-3 bg-bg-subtle/30 border-t border-bd-subtle">
+        <div>
+          <div className="text-[10px] uppercase text-fg-dim mb-1">Detail</div>
+          <pre className="text-[11px] mono text-fg-muted whitespace-pre-wrap break-words">{g.detail}</pre>
+        </div>
+        {showDiff ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {expected !== undefined && (
+              <div>
+                <div className="text-[10px] uppercase text-fg-dim mb-1">Expected</div>
+                <pre className="text-[10px] mono text-fg bg-bg p-2 rounded border border-bd-subtle overflow-auto max-h-96 whitespace-pre-wrap break-words">{String(expected)}</pre>
+              </div>
+            )}
+            <div className={expected === undefined ? "md:col-span-2" : ""}>
+              <div className="text-[10px] uppercase text-fg-dim mb-1">Actual</div>
+              <pre className="text-[10px] mono text-fg bg-bg p-2 rounded border border-bd-subtle overflow-auto max-h-96 whitespace-pre-wrap break-words">{actual}</pre>
+            </div>
+          </div>
+        ) : g.output ? (
+          <div>
+            <div className="text-[10px] uppercase text-fg-dim mb-1">Output</div>
+            <pre className="text-[11px] mono text-fg-dim bg-bg p-2 rounded border border-bd-subtle overflow-auto max-h-96 whitespace-pre-wrap break-words">{g.output}</pre>
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+const MAX_ENTRY_LEN = 8000;
+
+function Transcript({ transcript }: { transcript: TranscriptEntry[] }) {
+  return (
+    <div className="font-mono text-[12px]">
+      {transcript.map((entry, i) => (
+        <TranscriptEntryRow key={entry.uuid || i} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+function TranscriptEntryRow({ entry }: { entry: TranscriptEntry }) {
+  const [showMore, setShowMore] = useState(false);
+  let budget = showMore ? Infinity : MAX_ENTRY_LEN;
+  let cut = false;
+
+  const blocks = entry.content.map((block, j) => {
+    if (cut) return null;
+    if (block.type === "text") {
+      const text = budget === Infinity ? block.text : block.text.slice(0, Math.max(0, budget));
+      if (budget !== Infinity) budget = Math.max(0, budget - text.length);
+      cut = budget === 0 && block.text.length > text.length;
+      return <pre key={j} className="px-4 py-2 text-fg whitespace-pre-wrap break-words">{text}</pre>;
+    }
+    if (block.type === "tool_use") {
+      const input = typeof block.input === "string" ? block.input : JSON.stringify(block.input);
+      if (budget !== Infinity) budget = Math.max(0, budget - input.length);
+      return (
+        <div key={j} className="px-4 py-2 flex items-start gap-2">
+          <Wrench className="size-3 text-accent-soft mt-0.5 shrink-0" />
+          <span className="text-accent-soft shrink-0">{block.name}</span>
+          <span className="text-fg-dim whitespace-pre-wrap break-words">{input}</span>
+        </div>
+      );
+    }
+    if (block.type === "tool_result") {
+      const max = budget === Infinity ? block.content.length : Math.max(0, budget);
+      const text = block.content.slice(0, max);
+      if (budget !== Infinity) budget = Math.max(0, budget - text.length);
+      cut = budget === 0 && block.content.length > text.length;
+      return (
+        <details key={j} className="group px-4 py-2">
+          <summary className="cursor-pointer text-[10px] uppercase text-fg-dim flex items-center gap-1 select-none">
+            <ChevronRight className="size-3 group-open:rotate-90 transition-transform" /> Tool result
+            {block.is_error && <span className="ml-1 text-err">(error)</span>}
+          </summary>
+          <pre className="mt-1 pl-5 text-[11px] mono text-fg-muted whitespace-pre-wrap border-l-2 border-bd-subtle break-words max-h-96 overflow-auto">{text}</pre>
+        </details>
+      );
+    }
+    return null;
+  });
+
+  return (
+    <div className="border-b border-bd-subtle last:border-0">
+      <div className="px-4 py-1.5 flex items-center gap-2 bg-bg-subtle/40">
+        <span className="text-[10px] uppercase tracking-wider text-fg-dim">{entry.role}</span>
+        {entry.atMs !== undefined && <span className="text-[10px] text-fg-dim mono">@ {entry.atMs}ms</span>}
+      </div>
+      {blocks}
+      {(cut || showMore) && (
+        <button
+          onClick={() => setShowMore(!showMore)}
+          className="px-4 py-1.5 text-[10px] text-accent-soft hover:underline"
+        >
+          {showMore ? "Show less" : "Show more"}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Improves the run detail page and its supporting routes:

- Surfaces errors prominently at the top of errored cases.
- Makes each grader result collapsible, with truncated summaries and expandable detail/output, plus a diff-style expected-vs-actual view for failing file_eq/file_contains graders.
- Renders the transcript in a readable format (role headings, tool_use calls, collapsible tool_results) with a per-entry 8000-character show-more affordance.
- Adds a per-case Re-run button that links to /runs/new with the case and model preselected.
- Adds the previously missing /runs/[id] detail route, /runs list route, and GET /api/runs/[id] + /api/runs/[id]/telemetry endpoints so live polling works.

Tested via npm run typecheck, npm run lint, and local dev-server curl of /runs and /runs/<id>.