### PR TITLE
Add zod runtime validation for case definitions

### DIFF
--- a/lib/cases.ts
+++ b/lib/cases.ts
@@ -3,10 +3,134 @@ import path from "node:path";
 import type { Dirent } from "node:fs";
 import { CASES_DIR } from "./config";
 import { z } from "zod";
-import type { CaseDefinition, Category } from "./types";
+import type { CaseDefinition } from "./types";
 
-const CaseSchema = z.object({
-  id: z.string(),
+const CATEGORIES = new Set(["agentic-swe", "single-tool", "reasoning"]);
+
+const GraderSpecSchema = z.intersection(
+  z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("exit_code"),
+      command: z.string(),
+      cwd: z.string().optional(),
+      env: z.record(z.string()).optional(),
+      timeout_ms: z.number().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("tests_pass"),
+      command: z.string(),
+      cwd: z.string().optional(),
+      env: z.record(z.string()).optional(),
+      timeout_ms: z.number().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("file_contains"),
+      path: z.string(),
+      pattern: z.string(),
+      negate: z.boolean().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("file_exists"),
+      path: z.string(),
+      negate: z.boolean().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("file_eq"),
+      path: z.string(),
+      expected: z.string(),
+      trim: z.boolean().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("regex_match"),
+      pattern: z.string(),
+      source: z.enum(["stdout", "final_text", "transcript"]).optional(),
+      negate: z.boolean().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("json_path"),
+      path: z.string(),
+      jsonpath: z.string(),
+      equals: z.unknown(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("files_unchanged"),
+      paths: z.array(z.string()),
+      fixture: z.string().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("file_deleted"),
+      path: z.string(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("git_diff_contains"),
+      pattern: z.string(),
+      negate: z.boolean().optional(),
+      pathFilter: z.string().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("checksum"),
+      path: z.string(),
+      algorithm: z.enum(["sha256", "md5"]).optional(),
+      expected: z.string(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("step"),
+      tool: z.string().optional(),
+      input_includes: z.string().optional(),
+      input_includes_any: z.array(z.string()).optional(),
+      at_index: z.number().optional(),
+      min_count: z.number().optional(),
+      before_tool: z.string().optional(),
+      negate: z.boolean().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("rubric_llm"),
+      rubric: z.string(),
+      min_score: z.number().optional(),
+      model: z.string().optional(),
+      weight: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal("manual"),
+      note: z.string().optional(),
+      weight: z.number().optional(),
+    }),
+  ]),
+  z.object({ forbidden: z.boolean().optional() })
+);
+
+const SetupSchema = z
+  .object({
+    type: z.enum(["none", "fixture", "git-clone"]),
+    fixture: z.string().optional(),
+    repo: z.string().optional(),
+    workdir_name: z.string().optional(),
+    init_git: z.boolean().optional(),
+  })
+  .refine((s) => s.type !== "git-clone" || s.repo !== undefined, {
+    message: "repo is required when type is git-clone",
+    path: ["repo"],
+  });
+const VisualSchema = z.object({
+  kind: z.enum(["svg", "threejs", "web_ui", "app_ui", "screenshot"]),
+  requires_vision_input: z.boolean().optional(),
+  expected_artifacts: z.array(z.string()).optional(),
+});
+
+export const CaseDefinitionSchema = z.object({
+  id: z.string().min(1),
   category: z.enum(["agentic-swe", "single-tool", "reasoning"]),
   difficulty: z.enum(["easy", "medium", "hard"]).optional(),
   name: z.string(),
@@ -15,13 +139,7 @@ const CaseSchema = z.object({
   split: z.enum(["public", "held_out"]).optional(),
   canary: z.string().optional(),
   prompt: z.string(),
-  setup: z.object({
-    type: z.enum(["none", "fixture", "git-clone"]),
-    fixture: z.string().optional(),
-    repo: z.string().optional(),
-    workdir_name: z.string().optional(),
-    init_git: z.boolean().optional(),
-  }).optional(),
+  setup: SetupSchema.optional(),
   runner: z.object({
     max_turns: z.number().optional(),
     timeout_seconds: z.number().optional(),
@@ -39,39 +157,120 @@ const CaseSchema = z.object({
     noop_max_score: z.number().optional(),
     known_bad: z.array(z.string()).optional(),
   }).optional(),
-  visual: z.object({
-    kind: z.enum(["svg", "threejs", "web_ui", "app_ui", "screenshot"]),
-    requires_vision_input: z.boolean().optional(),
-    expected_artifacts: z.array(z.string()).optional(),
-  }).optional(),
-  graders: z.array(z.any()).nonempty(),
+  visual: VisualSchema.optional(),
+  graders: z.array(GraderSpecSchema).min(1),
   pass_threshold: z.number().optional(),
 });
 
-let cache: CaseDefinition[] | null = null;
+export type ZodCaseDefinition = z.infer<typeof CaseDefinitionSchema>;
 
-export async function loadCases(opts: { force?: boolean } = {}): Promise<CaseDefinition[]> {
-  if (cache && !opts.force) return cache;
-  const out: CaseDefinition[] = [];
+export interface CaseLoadError {
+  file: string;
+  paths: string[];
+}
+
+function formatZodPath(path: Array<string | number>): string {
+  if (path.length === 0) return "(root)";
+  let out = "";
+  for (const segment of path) {
+    if (typeof segment === "number") out += `[${segment}]`;
+    else if (out === "") out = segment;
+    else out += `.${segment}`;
+  }
+  return out;
+}
+
+export function formatCaseLoadErrors(errors: CaseLoadError[]): string[] {
+  return errors.flatMap((e) => e.paths.map((p) => `${e.file}: ${p}`));
+}
+
+let casesWithErrorsCache: { cases: CaseDefinition[]; errors: CaseLoadError[] } | null = null;
+export async function loadCasesWithErrors(
+  opts: { force?: boolean } = {}
+): Promise<{ cases: CaseDefinition[]; errors: CaseLoadError[] }> {
+  if (casesWithErrorsCache && !opts.force) return casesWithErrorsCache;
+  const cases: CaseDefinition[] = [];
+  const errors: CaseLoadError[] = [];
   let entries: Dirent[] = [];
   try {
     entries = await fs.readdir(CASES_DIR, { withFileTypes: true });
-  } catch { cache = out; return out; }
+  } catch {
+    casesWithErrorsCache = { cases, errors };
+    return casesWithErrorsCache;
+  }
+  const categorySet = CATEGORIES;
   for (const ent of entries) {
     if (!ent.isDirectory()) continue;
+    if (!categorySet.has(ent.name)) continue;
     const catDir = path.join(CASES_DIR, ent.name);
-    if (!["agentic-swe", "single-tool", "reasoning"].includes(ent.name)) continue;
     const files = await fs.readdir(catDir);
     for (const f of files) {
       if (!f.endsWith(".case.json")) continue;
       const full = path.join(catDir, f);
-      const text = await fs.readFile(full, "utf8");
-      const parsed = CaseSchema.parse(JSON.parse(text));
-      out.push(parsed as CaseDefinition);
+      const relative = path.relative(CASES_DIR, full);
+      let parsedJson: unknown;
+      try {
+        const text = await fs.readFile(full, "utf8");
+        parsedJson = JSON.parse(text);
+      } catch {
+        errors.push({ file: relative, paths: ["(invalid JSON)"] });
+        continue;
+      }
+      const result = CaseDefinitionSchema.safeParse(parsedJson);
+      if (result.success) {
+        cases.push(result.data as CaseDefinition);
+      } else {
+        const issuePaths = result.error.issues.map((issue) => formatZodPath(issue.path));
+        errors.push({ file: relative, paths: [...new Set(issuePaths)] });
+      }
     }
   }
-  cache = out.sort((a, b) => a.id.localeCompare(b.id));
-  return cache;
+  cases.sort((a, b) => a.id.localeCompare(b.id));
+  casesWithErrorsCache = { cases, errors };
+  return casesWithErrorsCache;
+}
+export async function loadCases(
+  opts: { force?: boolean } = {}
+): Promise<CaseDefinition[]> {
+  if (casesWithErrorsCache && !opts.force) return casesWithErrorsCache.cases;
+  const { cases } = await loadCasesWithErrors(opts);
+  return cases;
+}
+
+export async function loadCasesStrict(
+  opts: { force?: boolean } = {}
+): Promise<CaseDefinition[]> {
+  const cases: CaseDefinition[] = [];
+  let entries: Dirent[] = [];
+  try {
+    entries = await fs.readdir(CASES_DIR, { withFileTypes: true });
+  } catch {
+    return cases;
+  }
+  const categorySet = CATEGORIES;
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    if (!categorySet.has(ent.name)) continue;
+    const catDir = path.join(CASES_DIR, ent.name);
+    const files = await fs.readdir(catDir);
+    for (const f of files) {
+      if (!f.endsWith(".case.json")) continue;
+      const full = path.join(catDir, f);
+      const relative = path.relative(CASES_DIR, full);
+      const text = await fs.readFile(full, "utf8");
+      const parsed = JSON.parse(text);
+      const result = CaseDefinitionSchema.safeParse(parsed);
+      if (!result.success) {
+        const issue = result.error.issues[0];
+        const failingPath = formatZodPath(issue?.path ?? []);
+        throw new Error(
+          `Validation failed for ${relative}: ${failingPath} — ${issue?.message ?? "unknown error"}`
+        );
+      }
+      cases.push(result.data as CaseDefinition);
+    }
+  }
+  return cases.sort((a, b) => a.id.localeCompare(b.id));
 }
 
 export async function getCase(id: string): Promise<CaseDefinition | null> {


### PR DESCRIPTION
Implements CaseDefinitionSchema with discriminated union GraderSpec validation, loadCasesWithErrors() for lenient loading with per-file error paths, and loadCasesStrict() for CI/test strictness. Existing loadCases() signature is preserved and all current cases validate.