### PR TITLE
Fix evaluation_json persistence in run_cases

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -75,6 +75,12 @@ function migrate(conn: Database.Database) {
   add("difficulty", "TEXT");
   add("budget_exceeded", "INTEGER DEFAULT 0");
   add("sample", "INTEGER DEFAULT 0");
+  const versionRow = conn.prepare("PRAGMA user_version").pluck().get() as number | undefined;
+  const version = versionRow ?? 0;
+  if (version < 1) {
+    try { conn.exec("UPDATE run_cases SET evaluation_json = NULL WHERE evaluation_json = grader_result_json"); } catch {}
+    try { conn.exec("PRAGMA user_version = 1"); } catch {}
+  }
 }
 
 export interface RunQuery {
@@ -129,7 +135,7 @@ export function insertRunCase(rc: RunCaseRecord & { seq: number }): void {
     rc.started_at, rc.ended_at, rc.workdir_path, rc.transcript_path,
     rc.runner_kind, rc.runner_result ? JSON.stringify(rc.runner_result) : null,
     rc.grader_result ? JSON.stringify(rc.grader_result) : null,
-    null, rc.budget_exceeded ? 1 : 0, JSON.stringify(rc.case_def), rc.error_msg, rc.seq, rc.sample ?? 0
+    rc.evaluation ? JSON.stringify(rc.evaluation) : null, rc.budget_exceeded ? 1 : 0, JSON.stringify(rc.case_def), rc.error_msg, rc.seq, rc.sample ?? 0
   );
 }
 
@@ -143,7 +149,7 @@ export function updateRunCase(id: string, patch: Partial<RunCaseRecord>): void {
     next.status, next.started_at, next.ended_at, next.transcript_path,
     next.runner_result ? JSON.stringify(next.runner_result) : null,
     next.grader_result ? JSON.stringify(next.grader_result) : null,
-    next.grader_result ? JSON.stringify(next.grader_result) : null,
+    next.evaluation ? JSON.stringify(next.evaluation) : null,
     next.budget_exceeded ? 1 : 0,
     next.error_msg, id
   );
@@ -187,6 +193,7 @@ function rowToRunCase(r: any): RunCaseRecord {
     runner_kind: r.runner_kind,
     runner_result: r.runner_result_json ? JSON.parse(r.runner_result_json) : null,
     grader_result: r.grader_result_json ? JSON.parse(r.grader_result_json) : null,
+    evaluation: r.evaluation_json ? JSON.parse(r.evaluation_json) : null,
     budget_exceeded: !!r.budget_exceeded,
     error_msg: r.error_msg,
     case_def: JSON.parse(r.case_def_json),

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -88,6 +88,7 @@ export async function executeCase(
     runner_kind: runnerKind,
     runner_result: null,
     grader_result: null,
+    evaluation: null,
     budget_exceeded: false,
     error_msg: null,
     case_def: def,
@@ -166,6 +167,7 @@ export async function executeCase(
       appendEvent(runId, "grader_result", { case_id: def.id, sample, type: (spec as any).type, passed: r.passed, detail: r.detail.slice(0, 200) }, def.id);
     }
     const evaluation = evaluate(graderResults, def.pass_threshold ?? 1);
+    rec.evaluation = evaluation;
     rec.grader_result = evaluation;
     if (rec.budget_exceeded) {
       rec.status = "failed";
@@ -180,7 +182,7 @@ export async function executeCase(
   }
 
   rec.ended_at = Date.now();
-  updateRunCase(rcId, { status: rec.status, ended_at: rec.ended_at, grader_result: rec.grader_result, budget_exceeded: rec.budget_exceeded, error_msg: rec.error_msg });
+  updateRunCase(rcId, { status: rec.status, ended_at: rec.ended_at, grader_result: rec.grader_result, evaluation: rec.evaluation, budget_exceeded: rec.budget_exceeded, error_msg: rec.error_msg });
   appendEvent(runId, "case_finished", { case_id: def.id, seq, sample, status: rec.status }, def.id);
   return rec;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -205,6 +205,7 @@ export interface RunCaseRecord {
   runner_kind: RunnerKind;
   runner_result: RunnerResult | null;
   grader_result: CaseEvaluation | null;
+  evaluation: CaseEvaluation | null;
   budget_exceeded?: boolean;
   error_msg: string | null;
   case_def: CaseDefinition;


### PR DESCRIPTION
Fixes a data-integrity bug where run_cases.evaluation_json was being set to a duplicate of grader_result_json.

- Adds RunCaseRecord.evaluation (CaseEvaluation | null).
- Persists the evaluation object to evaluation_json on insert/update.
- Deserializes evaluation_json into RunCaseRecord.evaluation on read.
- Threads the CaseEvaluation from evaluate() through executor to updateRunCase.
- Guards the cleanup migration with PRAGMA user_version so it only clears
  pre-existing duplicates once.