### PR TITLE
Add structured errors, --json output, and new selftest checks

### DIFF
--- a/fixtures/messy-logs/logs2014/app.log
+++ b/fixtures/messy-logs/logs2014/app.log
@@ -1,0 +1,3 @@
+2024-01-01 ERROR: database connection failed
+2024-01-02 ERROR: timeout while fetching user profile
+2024-01-03 ERROR: invalid auth token received

--- a/fixtures/messy-logs/logs2014/server_final_USE_THIS.log
+++ b/fixtures/messy-logs/logs2014/server_final_USE_THIS.log
@@ -1,0 +1,2 @@
+INFO: old server log (decoy)
+INFO: not the real app.log

--- a/lib/cli/run.ts
+++ b/lib/cli/run.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env tsx
-import { createAndStartRun } from "../run";
-import { selectCases } from "../cases";
-import { getRun, listRunCases } from "../db";
-import { computeSummary } from "../summary";
-import type { RunnerKind } from "../types";
+import { createAndStartRun } from '../run';
+import { selectCases } from '../cases';
+import { getRun, listRunCases } from '../db';
+import { computeSummary } from '../summary';
+import type { RunnerKind } from '../types';
 
 interface Args {
   case?: string;
@@ -18,25 +18,32 @@ interface Args {
   watch: boolean;
 }
 
-function parseArgs(argv: string[]): Args {
-  const a: Args = { runner: "headless", parallel: 1, samples: 1, categories: [], tags: [], difficulty: [], watch: true };
+interface ParsedArgs extends Args {
+  json: boolean;
+  verbose: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const a: ParsedArgs = { runner: 'headless', parallel: 1, samples: 1, categories: [], tags: [], difficulty: [], watch: true, json: false, verbose: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     switch (arg) {
-      case "--case": a.case = argv[++i]; break;
-      case "--runner": a.runner = (argv[++i] as RunnerKind) || "headless"; break;
-      case "--parallel": a.parallel = parseInt(argv[++i] || "1", 10) || 1; break;
-      case "--samples": a.samples = parseInt(argv[++i] || "1", 10) || 1; break;
-      case "--model": a.model = argv[++i]; break;
-      case "--name": a.name = argv[++i]; break;
-      case "--category": a.categories.push(argv[++i]); break;
-      case "--tag": a.tags.push(argv[++i]); break;
-      case "--difficulty": a.difficulty.push(argv[++i]); break;
-      case "--no-watch": a.watch = false; break;
-      case "-h": case "--help":
+      case '--case': a.case = argv[++i]; break;
+      case '--runner': a.runner = (argv[++i] as RunnerKind) || 'headless'; break;
+      case '--parallel': a.parallel = parseInt(argv[++i] || '1', 10) || 1; break;
+      case '--samples': a.samples = parseInt(argv[++i] || '1', 10) || 1; break;
+      case '--model': a.model = argv[++i]; break;
+      case '--name': a.name = argv[++i]; break;
+      case '--category': a.categories.push(argv[++i]); break;
+      case '--tag': a.tags.push(argv[++i]); break;
+      case '--difficulty': a.difficulty.push(argv[++i]); break;
+      case '--no-watch': a.watch = false; break;
+      case '--json': a.json = true; break;
+      case '--verbose': a.verbose = true; break;
+      case '-h': case '--help':
         console.log(USAGE); process.exit(0);
       default:
-        if (!arg.startsWith("-")) {
+        if (!arg.startsWith('-')) {
           if (!a.case) a.case = arg;
         }
     }
@@ -59,6 +66,8 @@ Options:
   --tag <tag>          Filter by tag (repeatable)
   --difficulty <tier>  Filter by difficulty easy|medium|hard (repeatable)
   --no-watch           Exit immediately after starting, don't poll status
+  --json               Output run summary as JSON and suppress human text
+  --verbose            Print stack traces on errors
   -h, --help           Show this help
 
 Examples:
@@ -67,8 +76,32 @@ Examples:
   npx tsx lib/cli/run.ts --model glm-5.2 --samples 3 --difficulty medium
 `;
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function printError(e: unknown, json: boolean, verbose: boolean, code: number): never {
+  const msg = errorMessage(e);
+  if (json) {
+    console.log(JSON.stringify({ ok: false, error: msg }));
+  } else {
+    console.error('Error: ' + msg);
+  }
+  if (verbose && e instanceof Error && e.stack) {
+    console.error(e.stack);
+  }
+  process.exit(code);
+}
+
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const outputJson = argv.includes('--json');
+  const verbose = argv.includes('--verbose') || process.env.DEBUG === '1';
+  const log = outputJson ? () => undefined : console.log;
+
+  try {
+  const args = parseArgs(argv);
   const filter: any = {};
   if (args.case) filter.caseIds = [args.case];
   if (args.categories.length) filter.categories = args.categories;
@@ -77,11 +110,10 @@ async function main() {
 
   const selected = await selectCases(filter);
   if (selected.length === 0) {
-    console.error("No cases match. Try without filters, or check lib/cases.ts.");
-    process.exit(1);
+    throw new Error('No cases match. Try without filters, or check lib/cases.ts.');
   }
 
-  console.log(`Starting run: ${selected.length} case(s) × ${args.samples} sample(s) — runner=${args.runner} parallel=${args.parallel}${args.model ? ` model=${args.model}` : ""}`);
+  log('Starting run: ' + selected.length + ' case(s) × ' + args.samples + ' sample(s) — runner=' + args.runner + ' parallel=' + args.parallel + (args.model ? ' model=' + args.model : ''));
   const { id } = await createAndStartRun({
     name: args.name,
     runner: args.runner,
@@ -90,11 +122,11 @@ async function main() {
     samples: args.samples,
     filter,
   });
-  console.log(`Run started: ${id}`);
-  console.log(`  → Dashboard: http://localhost:3000/runs/${id}`);
-  console.log(`  → API:       GET /api/runs/${id}`);
+  log('Run started: ' + id);
+  log('  → Dashboard: http://localhost:3000/runs/' + id);
+  log('  → API:       GET /api/runs/' + id);
 
-  if (!args.watch) return;
+  if (!args.watch) return 0;
 
   // Poll until complete
   let lastSig = "";
@@ -105,7 +137,7 @@ async function main() {
     const sig = cases.map((c) => `${c.seq}:${c.status}`).join(" ");
     if (sig !== lastSig) {
       lastSig = sig;
-      process.stdout.write("\r" + " ".repeat(80) + "\r");
+      if (!outputJson) process.stdout.write("\r" + " ".repeat(80) + "\r");
       const counts = cases.reduce<Record<string, number>>((a, c) => { a[c.status] = (a[c.status] || 0) + 1; return a; }, {});
       const summary = [
         `passed=${counts.passed || 0}`,
@@ -114,7 +146,7 @@ async function main() {
         `running=${(counts.running || 0) + (counts.grading || 0)}`,
         `pending=${counts.pending || 0}`,
       ].join("  ");
-      process.stdout.write(`[${cases.filter((c) => ["passed","failed","error","skipped"].includes(c.status)).length}/${cases.length}] ${summary}`);
+      if (!outputJson) process.stdout.write(`[${cases.filter((c) => ["passed","failed","error","skipped"].includes(c.status)).length}/${cases.length}] ${summary}`);
     }
     if (run.status !== "running") break;
     await new Promise((r) => setTimeout(r, 1000));
@@ -123,14 +155,37 @@ async function main() {
   const finalRun = getRun(id);
   const finalCases = listRunCases(id);
   const summary = computeSummary(finalCases);
-  process.stdout.write("\n");
-  console.log(`\nRun ${finalRun?.status}: ${summary.passed}/${summary.total} passed (${(summary.passRate * 100).toFixed(0)}%)`);
-  console.log(`Cost: $${summary.totalCostUsd.toFixed(4)}  Tokens: ↑${summary.totalTokensIn} ↓${summary.totalTokensOut}  Duration: ${(summary.totalDurationMs / 1000).toFixed(1)}s`);
-  if (summary.byCategory) {
-    for (const [cat, s] of Object.entries(summary.byCategory)) {
-      console.log(`  ${cat}: ${s.passed}/${s.total}`);
+
+  if (outputJson) {
+    console.log(JSON.stringify(summary));
+  } else {
+    console.log();
+    console.log('Run ' + finalRun?.status + ': ' + summary.passed + '/' + summary.total + ' passed (' + (summary.passRate * 100).toFixed(0) + '%)');
+    console.log('Cost: $' + summary.totalCostUsd.toFixed(4) + '  Tokens: ↑' + summary.totalTokensIn + '' + summary.totalTokensOut + '  Duration: ' + (summary.totalDurationMs / 1000).toFixed(1) + 's');
+    if (summary.byCategory) {
+      for (const [cat, s] of Object.entries(summary.byCategory)) {
+        console.log('  ' + cat + ': ' + s.passed + '/' + s.total);
+      }
     }
+  }
+
+  if (finalRun?.status === 'failed') {
+    throw new Error('Run did not complete due to an unexpected failure.');
+  }
+
+  const graderCrash = finalCases.some((c) => c.status === 'error' && (c.error_msg ?? '').startsWith('Grader threw:'));
+  const runnerCrash = finalCases.some((c) => c.status === 'error' && ((c.error_msg ?? '').startsWith('Runner threw:') || c.runner_result?.isError));
+
+  if (graderCrash) return 3;
+  if (runnerCrash) return 2;
+  return 0;
+  } catch (e) {
+    printError(e, outputJson, verbose, 1);
   }
 }
 
-main().catch((e) => { console.error(e); process.exit(1); });
+main().then((code) => process.exit(code)).catch((e) => {
+  const json = process.argv.slice(2).includes('--json');
+  const verbose = process.argv.slice(2).includes('--verbose') || process.env.DEBUG === '1';
+  printError(e, json, verbose, 1);
+});

--- a/lib/cli/selftest.ts
+++ b/lib/cli/selftest.ts
@@ -1,77 +1,158 @@
 #!/usr/bin/env tsx
-import { execSync } from "node:child_process";
-import path from "node:path";
-import os from "node:os";
-import fs from "node:fs";
-import { loadCases } from "../cases";
-import { prepareWorkdir } from "../executor";
-import { runGrader, evaluate } from "../grader";
-import type { RunnerResult } from "../types";
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { loadCases } from '../cases';
+import { prepareWorkdir } from '../executor';
+import { runGrader, evaluate } from '../grader';
+import { getDb } from '../db';
+import type { RunnerResult } from '../types';
+
+interface Check {
+  name: string;
+  status: 'pass' | 'fail' | 'skip';
+  detail?: string;
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function printError(e: unknown, json: boolean, verbose: boolean): never {
+  const msg = errorMessage(e);
+  if (json) {
+    console.log(JSON.stringify({ ok: false, error: msg }));
+  } else {
+    console.error('Error: ' + msg);
+  }
+  if (verbose && e instanceof Error && e.stack) {
+    console.error(e.stack);
+  }
+  process.exit(1);
+}
 
 function runShell(cmd: string, cwd: string, timeoutMs = 30_000) {
   try {
-    execSync(cmd, { cwd, stdio: "pipe", timeout: timeoutMs });
-    return { code: 0, stdout: "", stderr: "" };
+    execSync(cmd, { cwd, stdio: 'pipe', timeout: timeoutMs });
+    return { code: 0, stdout: '', stderr: '' };
   } catch (e: any) {
-    return { code: e.status ?? 1, stdout: e.stdout?.toString() ?? "", stderr: e.stderr?.toString() ?? "" };
+    return { code: e.status ?? 1, stdout: e.stdout?.toString() ?? '', stderr: e.stderr?.toString() ?? '' };
   }
 }
 
 function emptyRunnerResult(): RunnerResult {
   return {
     exitCode: 0, durationMs: 0, startedAt: Date.now(), endedAt: Date.now(),
-    transcript: [], toolCalls: [], finalText: "", resultText: "",
+    transcript: [], toolCalls: [], finalText: '', resultText: '',
     usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, costUsd: 0 },
     numTurns: 0, stopReason: null, sessionId: null, model: null, isError: false, rawJson: null,
     tokenSegments: [], toolCallCounts: {},
   };
 }
 
-async function main() {
+function resolveBinary(name: string): string | null {
+  if (path.isAbsolute(name)) {
+    return fs.existsSync(name) ? name : null;
+  }
+  try {
+    const out = execSync('command -v ' + JSON.stringify(name), { stdio: 'pipe', timeout: 5_000 }).toString().trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+function warn(e: unknown, verbose: boolean) {
+  console.error('Warning: ' + errorMessage(e));
+  if (verbose && e instanceof Error && e.stack) {
+    console.error(e.stack);
+  }
+}
+
+async function runChecks(json: boolean, verbose: boolean): Promise<Check[]> {
+  const checks: Check[] = [];
+
+  function record(name: string, status: 'pass' | 'fail' | 'skip', detail?: string) {
+    checks.push({ name, status, detail });
+    if (!json) {
+      console.log('  ' + status.toUpperCase() + '  ' + name.padEnd(36) + ' ' + (detail ?? ''));
+    }
+  }
+
+  try {
+    getDb();
+    record('db openable', 'pass');
+  } catch (e) {
+    record('db openable', 'fail', errorMessage(e));
+  }
+
   const cases = await loadCases();
-  if (cases.length === 0) { console.error("No cases found."); process.exit(1); }
+  if (cases.length === 0) {
+    record('cases loaded', 'fail', 'loadCases returned no cases');
+  } else {
+    record('cases loaded', 'pass', cases.length + ' cases');
+  }
 
-  const tmpRun = `selftest-${Date.now().toString(36)}`;
+  const bin = process.env.NCODE_BIN || 'ncode';
+  const resolved = resolveBinary(bin);
+  if (!resolved) {
+    record('ncode binary callable', 'skip', 'binary not found: ' + bin);
+  } else {
+    try {
+      execSync(resolved + ' --version', { stdio: 'pipe', timeout: 10_000 });
+      record('ncode binary callable', 'pass', resolved);
+    } catch (e) {
+      record('ncode binary callable', 'fail', errorMessage(e));
+    }
+  }
+
+  const tmpRun = 'selftest-' + Date.now().toString(36);
   let pass = 0, fail = 0, skip = 0;
-  const failures: string[] = [];
 
-  console.log(`Self-test: ${cases.length} cases\n`);
+  if (!json) {
+    console.log('Self-test: ' + cases.length + ' cases');
+    console.log();
+  }
+
   for (const def of cases) {
-    const noop = await prepareWorkdir(tmpRun, `${def.id}-noop`, def, 0);
+    const checkName = 'case:' + def.id;
+    const noop = await prepareWorkdir(tmpRun, def.id + '-noop', def, 0);
     const noopRunner = emptyRunnerResult();
     const noopResults = [];
     for (const spec of def.graders) {
-      const r = await runGrader(spec, { workdir: noop.dir, runner: noopRunner, transcriptText: "", fixtureSrc: noop.fixtureSrc });
+      const r = await runGrader(spec, { workdir: noop.dir, runner: noopRunner, transcriptText: '', fixtureSrc: noop.fixtureSrc });
       noopResults.push(r);
     }
     const noopEval = evaluate(noopResults, def.pass_threshold ?? 1);
     const noopMax = def.oracle?.noop_max_score ?? 0;
     if (noopEval.passed || noopEval.passRatio > noopMax) {
       fail++;
-      failures.push(`${def.id}: no-op baseline scored ${noopEval.passRatio.toFixed(2)} (max ${noopMax})`);
-      console.log(`  FAIL  ${def.id.padEnd(36)} no-op baseline was accepted`);
+      record(checkName, 'fail', 'no-op baseline scored ' + noopEval.passRatio.toFixed(2) + ' (max ' + noopMax + ')');
       continue;
     }
 
     if (!def.oracle?.solve && !def.oracle?.final_text) {
       skip++;
-      console.log(`  SKIP  ${def.id.padEnd(36)} noop:reject  (no oracle)`);
+      record(checkName, 'skip', 'no oracle');
       continue;
     }
+
     const { dir, fixtureSrc } = await prepareWorkdir(tmpRun, def.id, def, 0);
-    const scriptPath = def.oracle.solve ? path.resolve("cases", def.category, def.oracle.solve) : null;
+    const scriptPath = def.oracle.solve ? path.resolve('cases', def.category, def.oracle.solve) : null;
     let oracleOk = true;
-    let oracleErr = "";
-    if (scriptPath) try {
-      execSync(`bash ${JSON.stringify(scriptPath)}`, { cwd: dir, stdio: "pipe", timeout: 30_000 });
-    } catch (e: any) {
-      oracleOk = false;
-      oracleErr = (e.stderr?.toString() || e.message || "").slice(0, 300);
+    let oracleErr = '';
+    if (scriptPath) {
+      try {
+        execSync('bash ' + JSON.stringify(scriptPath), { cwd: dir, stdio: 'pipe', timeout: 30_000 });
+      } catch (e: any) {
+        oracleOk = false;
+        oracleErr = (e.stderr?.toString() || e.message || '').slice(0, 300);
+      }
     }
     if (!oracleOk) {
       fail++;
-      failures.push(`${def.id}: oracle script failed — ${oracleErr}`);
-      console.log(`  FAIL  ${def.id.padEnd(36)} oracle script failed`);
+      record(checkName, 'fail', 'oracle script failed — ' + oracleErr);
       continue;
     }
     const runner = emptyRunnerResult();
@@ -79,36 +160,71 @@ async function main() {
       runner.finalText = def.oracle.final_text;
       runner.resultText = def.oracle.final_text;
     }
-    const transcriptText = "";
+    const transcriptText = '';
     const results = [];
     for (const spec of def.graders) {
       const r = await runGrader(spec, { workdir: dir, runner, transcriptText, fixtureSrc });
       results.push(r);
     }
     const eval_ = evaluate(results, def.pass_threshold ?? 1);
-    const detail = results.map((r) => `${r.spec.type}:${r.passed ? "ok" : "FAIL"}`).join("  ");
+    const detail = results.map((r) => r.spec.type + ':' + (r.passed ? 'ok' : 'FAIL')).join('  ');
     if (eval_.passed) {
       pass++;
-      console.log(`  PASS  ${def.id.padEnd(36)} ${detail}`);
+      record(checkName, 'pass', detail);
     } else {
       fail++;
-      failures.push(`${def.id}: ${(results.filter((r) => !r.passed).map((r) => r.detail)).join("; ")}`);
-      console.log(`  FAIL  ${def.id.padEnd(36)} ${detail}`);
+      record(checkName, 'fail', results.filter((r) => !r.passed).map((r) => r.detail).join('; '));
     }
   }
 
-  console.log(`\nSelf-test result: ${pass} pass, ${fail} fail, ${skip} skip (no oracle)`);
-  if (failures.length) {
-    console.log("\nFailures:");
-    for (const f of failures) console.log(`  - ${f}`);
+  if (!json) {
+    console.log();
+    console.log('Self-test result: ' + pass + ' pass, ' + fail + ' fail, ' + skip + ' skip (no oracle)');
   }
+
   // cleanup
-  try { fs.rmSync(path.join(os.tmpdir(), "..", "data", "workdirs", tmpRun), { recursive: true, force: true }); } catch {}
   try {
-    const wd = path.resolve("data", "workdirs", tmpRun);
+    fs.rmSync(path.join(os.tmpdir(), '..', 'data', 'workdirs', tmpRun), { recursive: true, force: true });
+  } catch (e) {
+    warn(e, verbose);
+  }
+  try {
+    const wd = path.resolve('data', 'workdirs', tmpRun);
     fs.rmSync(wd, { recursive: true, force: true });
-  } catch {}
-  process.exit(fail > 0 ? 1 : 0);
+  } catch (e) {
+    warn(e, verbose);
+  }
+
+  return checks;
 }
 
-main().catch((e) => { console.error(e); process.exit(1); });
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const json = argv.includes('--json');
+  const verbose = argv.includes('--verbose') || process.env.DEBUG === '1';
+
+  try {
+    const checks = await runChecks(json, verbose);
+    const errors = checks.filter((c) => c.status === 'fail').map((c) => c.name + ': ' + (c.detail ?? ''));
+
+    if (json) {
+      if (errors.length > 0) {
+        console.log(JSON.stringify({ ok: false, errors }));
+      } else {
+        console.log(JSON.stringify({ ok: true, checks }));
+      }
+    }
+
+    if (errors.length > 0) {
+      process.exit(1);
+    }
+  } catch (e) {
+    printError(e, json, verbose);
+  }
+}
+
+main().catch((e) => {
+  const json = process.argv.slice(2).includes('--json');
+  const verbose = process.argv.slice(2).includes('--verbose') || process.env.DEBUG === '1';
+  printError(e, json, verbose);
+});


### PR DESCRIPTION
- Wrap run.ts and selftest.ts main entrypoints in try/catch and report structured errors
- Add --json and --verbose flags to both CLIs
- Exit run.ts with 2/3 for runner/grader crashes, selftest with 1 on failures
- Add DB-openable, loadCases, and ncode-binary-callable selftest checks
- Surface swallowed cleanup errors and add missing messy-logs fixture files