### PR TITLE
Harden harness probing, transcript intelligence, and evidence paths

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { configuredDefaultModel, discoverModels, isValidModelId } from "@/lib/models";
-import { getAdapter, hasAdapter } from "@/lib/adapters/registry";
+import { discoverModels, isValidModelId, resolveDefaultModel } from "@/lib/models";
 
 export const dynamic = "force-dynamic";
 
@@ -8,10 +7,9 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const harness = searchParams.get("harness") ?? undefined;
   const models = discoverModels(harness);
-  const descriptorDefault = harness && hasAdapter(harness) ? getAdapter(harness).descriptor.models?.default : undefined;
-  const localDefault = harness ? configuredDefaultModel(harness) : undefined;
+  const resolvedDefault = harness ? resolveDefaultModel(harness) : { source: "none" as const };
   return NextResponse.json(
-    { models, defaultModel: descriptorDefault ?? localDefault ?? models[0]?.id ?? null },
+    { models, defaultModel: resolvedDefault.id ?? models[0]?.id ?? null, defaultModelSource: resolvedDefault.source },
     { headers: { "Cache-Control": "private, max-age=60, stale-while-revalidate=300" } }
   );
 }

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { discoverModels, isValidModelId } from "@/lib/models";
+import { configuredDefaultModel, discoverModels, isValidModelId } from "@/lib/models";
 import { getAdapter, hasAdapter } from "@/lib/adapters/registry";
 
 export const dynamic = "force-dynamic";
@@ -9,8 +9,9 @@ export async function GET(request: Request) {
   const harness = searchParams.get("harness") ?? undefined;
   const models = discoverModels(harness);
   const descriptorDefault = harness && hasAdapter(harness) ? getAdapter(harness).descriptor.models?.default : undefined;
+  const localDefault = harness ? configuredDefaultModel(harness) : undefined;
   return NextResponse.json(
-    { models, defaultModel: descriptorDefault ?? models[0]?.id ?? null },
+    { models, defaultModel: descriptorDefault ?? localDefault ?? models[0]?.id ?? null },
     { headers: { "Cache-Control": "private, max-age=60, stale-while-revalidate=300" } }
   );
 }

--- a/app/api/runs/[id]/case/[caseId]/artifact/route.ts
+++ b/app/api/runs/[id]/case/[caseId]/artifact/route.ts
@@ -33,7 +33,13 @@ export async function GET(
   }
 
   try {
-    const content = fs.readFileSync(fullPath, "utf8");
+    const realWorkdir = fs.realpathSync(rc.workdir_path);
+    const realArtifact = fs.realpathSync(fullPath);
+    const realRelative = path.relative(realWorkdir, realArtifact);
+    if (!realRelative || realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
+      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+    }
+    const content = fs.readFileSync(realArtifact, "utf8");
     const isTerminal = isTerminalCaseStatus(rc.status);
     const headers = isTerminal
       ? { "Cache-Control": "private, max-age=300, stale-while-revalidate=600" }

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,17 +1,19 @@
 import path from "node:path";
 import LiveClient from "@/components/LiveClient";
-import { defaultLiveLimitForHarness, scanLiveSessions, isPathInLiveSource, getErroringTurns, type LiveAggregate, type TranscriptResult } from "@/lib/live";
+import { defaultLiveLimitForHarness, scanLiveSessions, isPathInLiveSource, liveTraceFormatForHarness, getErroringTurns, type LiveAggregate, type TranscriptResult } from "@/lib/live";
 
 export const dynamic = "force-dynamic";
 
 async function getSessionTranscript(filePath: string, harness?: string): Promise<TranscriptResult> {
   "use server";
   const normalized = path.resolve(filePath);
-  if (!normalized.endsWith(".jsonl") || !isPathInLiveSource(normalized, harness)) {
+  const format = liveTraceFormatForHarness(harness);
+  const supportedExtension = normalized.endsWith(".jsonl") || (format === "hermes-json" && normalized.endsWith(".json"));
+  if (!supportedExtension || !isPathInLiveSource(normalized, harness)) {
     return { turns: [], error: "Invalid session path" };
   }
   try {
-    return getErroringTurns(normalized);
+    return getErroringTurns(normalized, format);
   } catch (e) {
     return { turns: [], error: `Failed to parse session transcript: ${e instanceof Error ? e.message : String(e)}` };
   }

--- a/components/HarnessesClient.tsx
+++ b/components/HarnessesClient.tsx
@@ -162,7 +162,7 @@ export default function HarnessesClient() {
                 <Field label="Version">{active.version ?? "—"}</Field>
                 <Field label="Source">{active.source}</Field>
                 <Field label="Output format">{active.capabilities.outputFormat}</Field>
-                <Field label="Vision input">{active.capabilities.supportsVisionInput ? "yes" : "no"}</Field>
+                <Field label="Vision input">{capabilityLabel(active.capabilities.supportsVisionInput)}</Field>
               </dl>
 
               <div className="mt-4">
@@ -177,8 +177,8 @@ export default function HarnessesClient() {
                   <span className={clsx("inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] mono", active.capabilities.reportsTurns ? "bg-ok/10 text-ok" : "bg-bg-elev text-fg-dim")}>
                     {active.capabilities.reportsTurns ? <CheckCircle2 className="size-2.5" /> : <XCircle className="size-2.5" />} turns
                   </span>
-                  <span className={clsx("inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] mono", active.capabilities.supportsVisionInput ? "bg-ok/10 text-ok" : "bg-bg-elev text-fg-dim")}>
-                    {active.capabilities.supportsVisionInput ? <CheckCircle2 className="size-2.5" /> : <XCircle className="size-2.5" />} vision
+                  <span className={clsx("inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] mono", capabilityClass(active.capabilities.supportsVisionInput))}>
+                    {active.capabilities.supportsVisionInput === true ? <CheckCircle2 className="size-2.5" /> : active.capabilities.supportsVisionInput === false ? <XCircle className="size-2.5" /> : <span className="size-2.5 text-center">?</span>} vision {active.capabilities.supportsVisionInput === null ? "unknown" : ""}
                   </span>
                 </div>
               </div>
@@ -202,7 +202,7 @@ export default function HarnessesClient() {
               )}
 
               <div className="mt-4 pt-3 border-t border-bd-subtle text-[10px] text-fg-dim">
-                Permission modes: {active.capabilities.permissionModes.join(", ")}
+                Permission modes: {active.capabilities.permissionModes.length > 0 ? active.capabilities.permissionModes.join(", ") : "none declared"}
               </div>
             </section>
           )}
@@ -219,4 +219,12 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
       <dd className="mt-0.5 mono text-sm break-all">{children}</dd>
     </div>
   );
+}
+
+function capabilityLabel(value: boolean | null): string {
+  return value === true ? "yes" : value === false ? "no" : "unknown";
+}
+
+function capabilityClass(value: boolean | null): string {
+  return value === true ? "bg-ok/10 text-ok" : value === false ? "bg-bg-elev text-fg-dim" : "bg-warn/10 text-warn";
 }

--- a/components/HarnessesClient.tsx
+++ b/components/HarnessesClient.tsx
@@ -163,6 +163,9 @@ export default function HarnessesClient() {
                 <Field label="Source">{active.source}</Field>
                 <Field label="Output format">{active.capabilities.outputFormat}</Field>
                 <Field label="Vision input">{capabilityLabel(active.capabilities.supportsVisionInput)}</Field>
+                <Field label="Local image attachments">{active.imageFlag ? `yes (${active.imageFlag})` : "not wired"}</Field>
+                <Field label="Probe">{active.probe ? `version ${active.probe.version.ok ? "ok" : "failed"}${active.probe.help ? ` · help ${active.probe.help.ok ? "ok" : "failed"}` : ""}` : "not run"}</Field>
+                <Field label="Image flag probe">{active.probe?.imageFlagObserved == null ? "not observed" : active.probe.imageFlagObserved ? "observed" : "not observed"}</Field>
               </dl>
 
               <div className="mt-4">
@@ -192,6 +195,12 @@ export default function HarnessesClient() {
                 <pre className="text-[11px] mono bg-bg border border-bd-subtle rounded-md p-3 overflow-x-auto whitespace-pre-wrap break-all">
                   {active.sampleCommand ? `${active.sampleCommand.bin} ${active.sampleCommand.args.join(" ")}` : "—"}
                 </pre>
+                {active.sampleCommand && Object.keys(active.sampleCommand.env ?? {}).length > 0 && (
+                  <div className="mt-2 text-[10px] mono text-fg-dim">Environment: {Object.entries(active.sampleCommand.env ?? {}).map(([key, value]) => `${key}=${value}`).join(" ")}</div>
+                )}
+                {active.sampleCommand?.stdin != null && (
+                  <div className="mt-2 text-[10px] mono text-fg-dim">Stdin prompt: {active.sampleCommand.stdin}</div>
+                )}
               </div>
 
               {active.detail && (

--- a/components/LiveClient.tsx
+++ b/components/LiveClient.tsx
@@ -581,7 +581,7 @@ const SessionRow = React.memo(function SessionRow({ session, redact, users, onSe
               <span>·</span>
             </>
           ) : null}
-          <span>{session.model || "model missing"}</span>
+          <span>{displayText(session.model || "model missing", redact, users)}</span>
           {session.traceGraph.sidechainMessages > 0 ? <span className="rounded bg-accent/10 px-1.5 py-0.5 text-accent-soft">{session.traceGraph.sidechainMessages} side</span> : null}
           {session.traceGraph.agentCount > 0 ? <span className="rounded bg-bg-elev px-1.5 py-0.5 text-fg-muted">{session.traceGraph.agentCount} agent</span> : null}
           {session.modeSummary.gitBranch ? <span className="rounded bg-bg-elev px-1.5 py-0.5 text-fg-muted">{displayText(session.modeSummary.gitBranch, redact, users)}</span> : null}
@@ -737,7 +737,7 @@ function SessionDrawer({
         <div className="drawer-stagger flex-1 space-y-5 overflow-y-auto p-5">
           <section className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
             <MetricCard label="Project" value={compactDisplayPath(session.project || "(unknown)", redact)} />
-            <MetricCard label="Model" value={session.model || "missing"} source={session.metricSources.model} />
+            <MetricCard label="Model" value={displayText(session.model || "missing", redact, users)} source={session.metricSources.model} />
             <MetricCard label="Duration" value={session.metricSources.duration === "missing" ? "missing" : fmtMs(session.durationMs)} source={session.metricSources.duration} />
             <MetricCard label="Tokens" value={session.metricSources.tokens === "missing" ? "missing" : fmt(session.inputTokens + session.outputTokens)} source={session.metricSources.tokens} />
           </section>
@@ -821,10 +821,10 @@ function SessionDrawer({
             <DetailPanel title="Modes / repo">
               <div className="space-y-2 text-xs text-fg-muted">
                 <div className="flex justify-between gap-3"><span>Branch</span><span className="mono truncate">{displayText(session.modeSummary.gitBranch ?? "missing", redact, users)}</span></div>
-                <div className="flex justify-between gap-3"><span>Entrypoint</span><span className="mono">{session.modeSummary.entrypoint ?? "missing"}</span></div>
+                <div className="flex justify-between gap-3"><span>Entrypoint</span><span className="mono">{displayText(session.modeSummary.entrypoint ?? "missing", redact, users)}</span></div>
                 <div className="flex flex-wrap gap-1.5">
                   {Object.entries(session.modeSummary.permissionModes).map(([mode, count]) => (
-                    <span key={mode} className="rounded bg-bg-elev px-1.5 py-0.5 text-[10px]">{mode}: {count}</span>
+                    <span key={mode} className="rounded bg-bg-elev px-1.5 py-0.5 text-[10px]">{displayText(mode, redact, users)}: {displayText(count, redact, users)}</span>
                   ))}
                 </div>
               </div>

--- a/components/ModelPicker.tsx
+++ b/components/ModelPicker.tsx
@@ -65,8 +65,8 @@ export default function ModelPicker({ value, onChange, harness }: Props) {
           {selected && (
             <span className="text-[10px] text-fg-dim mono px-1.5 py-0.5 rounded bg-bg-elev shrink-0">{selected.family}</span>
           )}
-          {selected?.capabilities.visualCodeOutput && <ImageIcon className="size-3 text-ok shrink-0" />}
-          {selected && !selected.capabilities.visionInput && <EyeOff className="size-3 text-fg-dim shrink-0" />}
+          {selected?.capabilities.visualCodeOutput === true && <ImageIcon className="size-3 text-ok shrink-0" />}
+          {selected?.capabilities.visionInput === false && <EyeOff className="size-3 text-fg-dim shrink-0" />}
         </span>
         <ChevronDown className="size-3.5 text-fg-dim shrink-0" />
       </button>
@@ -124,7 +124,7 @@ export default function ModelPicker({ value, onChange, harness }: Props) {
                     {m.family}
                   </span>
                   <span className="text-[9px] uppercase tracking-wider mono px-1.5 py-0.5 rounded shrink-0 bg-bg-elev text-fg-dim">
-                    {m.capabilities.visionInput ? "vision" : "blind"}
+                    {m.capabilities.visionInput === true ? "vision" : m.capabilities.visionInput === false ? "no vision" : "vision ?"}
                   </span>
                   {m.capabilities.visualCodeOutput && (
                     <span className="text-[9px] uppercase tracking-wider mono px-1.5 py-0.5 rounded shrink-0 bg-ok/10 text-ok">

--- a/docs/case-authoring.md
+++ b/docs/case-authoring.md
@@ -75,6 +75,7 @@ Oracles matter because `npm run selftest` first grades a no-op baseline and fail
 | --- | --- | --- |
 | `kind` | `svg`, `threejs`, `web_ui`, `app_ui`, or `screenshot` | Visual artifact class. |
 | `requires_vision_input` | boolean | Marks cases that require visual input. |
+| `input_images` | string[] | Paths relative to the prepared workdir. The selected harness must declare an `imageFlag`; each path is attached to the initial prompt. Required when `requires_vision_input` is true. |
 | `expected_artifacts` | string[] | Artifact names/contracts. The accuracy audit counts these as visual evidence. |
 
 ## Graders

--- a/docs/harness-authoring.md
+++ b/docs/harness-authoring.md
@@ -32,6 +32,7 @@ npm run run:case -- swe-fix-fizzbuzz --harness <id>
 | `binEnvVar` | string, optional | Environment variable that overrides the binary path at command-build time. |
 | `wellKnownPaths` | string[], optional | Extra executable paths for discovery. `~` is expanded in discovery. |
 | `versionArgs` | string[], default `["--version"]` | Arguments used for the version probe. |
+| `helpArgs` | string[], default `["--help"]` | Safe, non-spending arguments used for the CLI help probe. Set `[]` to skip it. |
 | `parser` | `claude-stream-json`, `codex-jsonl`, `generic-jsonl`, or `text`; required unless `output` is set | Selects stdout line parser. |
 | `output` | legacy `stream-json`, `jsonl`, `json`, or `text`; optional | Back-compat mapping: `stream-json` to `claude-stream-json`; `jsonl` and `json` to `generic-jsonl`; `text` to `text`. |
 | `argTemplate` | string[], required | Initial command arguments. Tokens may contain substitutions. |
@@ -40,6 +41,7 @@ npm run run:case -- swe-fix-fizzbuzz --harness <id>
 | `workdirFlag` | string, optional | Appended with the workdir unless `{workdir}` already appears in `argTemplate`. |
 | `modelFlag` | string, optional | Appended with the selected model only when a model is set and `{model}` is not already in `argTemplate`. |
 | `maxTurnsFlag` | string, optional | Appended with max turns only when `maxTurns > 0` and `{maxTurns}` is not already in `argTemplate`. |
+| `imageFlag` | string, optional | Repeated with each local image path supplied by `visual.input_images`. |
 | `permissionFlag` | string, optional | Simple permission form: appends `<permissionFlag> <permissionMode>`. |
 | `permissionArgs` | object of string[] by permission mode, optional | Full permission form. Uses the selected mode key, then `"*"` as fallback. Values support substitutions. |
 | `appendExtraArgs` | boolean, default `true` | Whether `runner.extra_args` from a case is appended. |
@@ -109,7 +111,9 @@ For `generic-jsonl`, a line with `toolCallName` emits a `tool_use` event and a l
 - `supportsVisionInput`
 - `permissionModes`
 
-Without overrides, structured parsers (`claude-stream-json`, `codex-jsonl`) report cost/tokens/turns; generic descriptors report those capabilities when the corresponding mapped fields exist. `supportsVisionInput` defaults to `unknown` (`null`) because an omitted flag is not evidence that a harness cannot accept images. `permissionModes` defaults to all permission modes from the schema; descriptors should override it with an explicit list when the CLI exposes a narrower surface.
+The optional `imageFlag` enables real local-image attachments. It is repeated as `imageFlag <path>` for every `visual.input_images` entry. A harness can still have model/provider vision support without declaring a local attachment flag; OpenEval reports that distinction and rejects image cases it cannot wire safely.
+
+Without overrides, structured parsers (`claude-stream-json`, `codex-jsonl`) report cost/tokens/turns; generic descriptors report those capabilities when the corresponding mapped fields exist. `supportsVisionInput` defaults to `unknown` (`null`) because an omitted flag is not evidence that a harness cannot accept images. `permissionModes` defaults to all permission modes from the schema; descriptors should override it with an explicit list when the CLI exposes a narrower surface. `helpArgs` defaults to `["--help"]` and is used for a safe, non-spending probe; set it to an empty array only when a CLI has no help probe.
 
 ## Live Trace
 
@@ -117,7 +121,7 @@ Without overrides, structured parsers (`claude-stream-json`, `codex-jsonl`) repo
 
 | Field | Type / default | Purpose |
 | --- | --- | --- |
-| `format` | `claude-projects`, `codex-sessions`, or `jsonl-dir`; default `jsonl-dir` | Parser and directory layout for `/live`. |
+| `format` | `claude-projects`, `codex-sessions`, `jsonl-dir`, or `hermes-json`; default `jsonl-dir` | Parser and directory layout for `/live`. `hermes-json` handles one pretty-printed JSON document per session. |
 | `roots` | string[], required | Roots to scan. `~` expands to the home directory. |
 | `maxDepth` | positive integer, optional | Recursive depth for `jsonl-dir` and `codex-sessions`; default is `5` for Codex, `2` for Claude-projects, `4` for generic JSONL. |
 | `fields` | `FieldMapping`, optional | Generic field mappings for live metrics. For `jsonl-dir`, adapter fields are used when omitted. |
@@ -149,8 +153,9 @@ The model API returns descriptor aliases, discovered config models, and the desc
 1. Start with `argTemplate` after substitutions.
 2. Append `permissionArgs[permissionMode]`, or `permissionArgs["*"]`, or `<permissionFlag> <permissionMode>`.
 3. Append `workdirFlag`, `modelFlag`, and `maxTurnsFlag` when present and not already represented by placeholders in `argTemplate`; `modelFlag` requires a selected model, and `maxTurnsFlag` requires `maxTurns > 0`.
-4. Append case `extra_args` unless `appendExtraArgs` is `false`.
-5. Add the prompt by mode: trailing arg, flag pair, stdin, or no-op for template mode.
+4. Append the repeated `imageFlag <absolute-image-path>` pairs for any case input images.
+5. Append case `extra_args` unless `appendExtraArgs` is `false`.
+6. Add the prompt by mode: trailing arg, flag pair, stdin, or no-op for template mode.
 
 The spawned process runs in the prepared workdir with `process.env` plus `extraEnv`.
 
@@ -165,41 +170,38 @@ This example is based on `harnesses/hermes.harness.json`, with inline annotation
   "binNames": ["hermes"],
   "wellKnownPaths": ["~/.local/bin/hermes", "~/.hermes/bin/hermes"],
   "versionArgs": ["--version"],
-  "output": "jsonl",
-  "argTemplate": ["run", "--json", "--workdir", "{workdir}"],
-  "prompt": { "mode": "flag", "flag": "--prompt" },
-  "extraEnv": {},
-  "fields": {
-    "finalText": "message.text",
-    "sessionId": "session_id",
-    "model": "model",
-    "toolCallName": "tool.name",
-    "toolCallId": "tool.id",
-    "toolCallInput": "tool.input",
-    "toolCallOutput": "result.output",
-    "toolCallError": "result.is_error",
-    "durationMs": "duration_ms",
-    "numTurns": "num_turns",
-    "inputTokens": "usage.input_tokens",
-    "outputTokens": "usage.output_tokens",
-    "costUsd": "usage.cost_usd",
-    "stopReason": "stop_reason",
-    "isError": "is_error"
+  "helpArgs": ["chat", "--help"],
+  "parser": "text",
+  "argTemplate": ["chat", "--query", "{prompt}", "--quiet", "--cli"],
+  "prompt": { "mode": "template" },
+  "modelFlag": "--model",
+  "maxTurnsFlag": "--max-turns",
+  "imageFlag": "--image",
+  "capabilities": {
+    "reportsCost": false,
+    "reportsTokens": false,
+    "reportsTurns": false,
+    "supportsVisionInput": true,
+    "permissionModes": []
+  },
+  "liveTrace": {
+    "format": "hermes-json",
+    "roots": ["~/.hermes/sessions"],
+    "maxDepth": 1
   }
 }
 ```
 
 Notes:
 
-- `output: "jsonl"` is the legacy spelling for `parser: "generic-jsonl"`.
-- `{workdir}` is already in `argTemplate`, so no `workdirFlag` is needed.
-- The prompt is sent as `--prompt <case prompt>`.
-- Because the parser is generic JSONL, `fields` is required.
+- Hermes stores one pretty-printed JSON document per session, so live metrics and transcript viewing use the `hermes-json` trace format rather than a line parser.
+- The prompt is substituted into `--query`; `imageFlag` is repeated for each `visual.input_images` path.
+- Hermes records no token or cost usage, so those capabilities remain explicitly false.
 
 With a case workdir of `/tmp/workdir`, prompt `Fix the bug`, and permission mode `bypassPermissions`, the sample command shape is:
 
 ```bash
-hermes run --json --workdir /tmp/workdir --prompt "Fix the bug"
+hermes chat --query "Fix the bug" --quiet --cli
 ```
 
 ## Bundled Descriptors

--- a/docs/harness-authoring.md
+++ b/docs/harness-authoring.md
@@ -109,7 +109,7 @@ For `generic-jsonl`, a line with `toolCallName` emits a `tool_use` event and a l
 - `supportsVisionInput`
 - `permissionModes`
 
-Without overrides, structured parsers (`claude-stream-json`, `codex-jsonl`) report cost/tokens/turns; generic descriptors report those capabilities when the corresponding mapped fields exist. `supportsVisionInput` defaults to `false`, and `permissionModes` defaults to all permission modes from the schema.
+Without overrides, structured parsers (`claude-stream-json`, `codex-jsonl`) report cost/tokens/turns; generic descriptors report those capabilities when the corresponding mapped fields exist. `supportsVisionInput` defaults to `unknown` (`null`) because an omitted flag is not evidence that a harness cannot accept images. `permissionModes` defaults to all permission modes from the schema; descriptors should override it with an explicit list when the CLI exposes a narrower surface.
 
 ## Live Trace
 
@@ -222,7 +222,11 @@ Bundled Claude Code, Codex, and ncode descriptors use the same schema. For examp
   },
   "modelFlag": "-m",
   "prompt": { "mode": "arg" },
-  "capabilities": { "reportsCost": false },
+  "capabilities": {
+    "reportsCost": false,
+    "supportsVisionInput": true,
+    "permissionModes": ["bypassPermissions", "default"]
+  },
   "liveTrace": {
     "format": "codex-sessions",
     "roots": ["~/.codex/sessions", "~/.codex/archived_sessions"],

--- a/harnesses/hermes.harness.json
+++ b/harnesses/hermes.harness.json
@@ -4,25 +4,16 @@
   "binNames": ["hermes"],
   "wellKnownPaths": ["~/.local/bin/hermes", "~/.hermes/bin/hermes"],
   "versionArgs": ["--version"],
-  "output": "jsonl",
-  "argTemplate": ["run", "--json", "--workdir", "{workdir}"],
-  "prompt": { "mode": "flag", "flag": "--prompt" },
-  "extraEnv": {},
-  "fields": {
-    "finalText": "message.text",
-    "sessionId": "session_id",
-    "model": "model",
-    "toolCallName": "tool.name",
-    "toolCallId": "tool.id",
-    "toolCallInput": "tool.input",
-    "toolCallOutput": "result.output",
-    "toolCallError": "result.is_error",
-    "durationMs": "duration_ms",
-    "numTurns": "num_turns",
-    "inputTokens": "usage.input_tokens",
-    "outputTokens": "usage.output_tokens",
-    "costUsd": "usage.cost_usd",
-    "stopReason": "stop_reason",
-    "isError": "is_error"
+  "parser": "text",
+  "argTemplate": ["chat", "--query", "{prompt}", "--quiet", "--cli"],
+  "prompt": { "mode": "template" },
+  "modelFlag": "--model",
+  "maxTurnsFlag": "--max-turns",
+  "capabilities": {
+    "reportsCost": false,
+    "reportsTokens": false,
+    "reportsTurns": false,
+    "supportsVisionInput": true,
+    "permissionModes": []
   }
 }

--- a/harnesses/hermes.harness.json
+++ b/harnesses/hermes.harness.json
@@ -4,16 +4,23 @@
   "binNames": ["hermes"],
   "wellKnownPaths": ["~/.local/bin/hermes", "~/.hermes/bin/hermes"],
   "versionArgs": ["--version"],
+  "helpArgs": ["chat", "--help"],
   "parser": "text",
   "argTemplate": ["chat", "--query", "{prompt}", "--quiet", "--cli"],
   "prompt": { "mode": "template" },
   "modelFlag": "--model",
   "maxTurnsFlag": "--max-turns",
+  "imageFlag": "--image",
   "capabilities": {
     "reportsCost": false,
     "reportsTokens": false,
     "reportsTurns": false,
     "supportsVisionInput": true,
     "permissionModes": []
+  },
+  "liveTrace": {
+    "format": "hermes-json",
+    "roots": ["~/.hermes/sessions"],
+    "maxDepth": 1
   }
 }

--- a/lib/adapters/builtin.ts
+++ b/lib/adapters/builtin.ts
@@ -22,10 +22,10 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     capabilities: { supportsVisionInput: true },
     models: {
       aliases: [
-        { id: "opus", label: "Opus", family: "opus" },
-        { id: "sonnet", label: "Sonnet", family: "sonnet" },
-        { id: "sonnet[1m]", label: "Sonnet 1M", family: "sonnet" },
-        { id: "haiku", label: "Haiku", family: "haiku" },
+        { id: "opus", label: "Opus", family: "opus", capabilities: { visionInput: true, visualCodeOutput: true } },
+        { id: "sonnet", label: "Sonnet", family: "sonnet", capabilities: { visionInput: true, visualCodeOutput: true } },
+        { id: "sonnet[1m]", label: "Sonnet 1M", family: "sonnet", capabilities: { visionInput: true, visualCodeOutput: true } },
+        { id: "haiku", label: "Haiku", family: "haiku", capabilities: { visionInput: true, visualCodeOutput: true } },
       ],
     },
     liveTrace: {
@@ -49,7 +49,14 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     },
     modelFlag: "-m",
     prompt: { mode: "arg" },
-    capabilities: { reportsCost: false },
+    // `codex --help` exposes `-i/--image` for both interactive and `exec`
+    // modes. Cost is intentionally false because JSONL output does not report
+    // a measured USD field.
+    capabilities: {
+      reportsCost: false,
+      supportsVisionInput: true,
+      permissionModes: ["bypassPermissions", "default"],
+    },
     liveTrace: {
       format: "codex-sessions",
       roots: ["~/.codex/sessions", "~/.codex/archived_sessions"],

--- a/lib/adapters/builtin.ts
+++ b/lib/adapters/builtin.ts
@@ -18,8 +18,9 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     workdirFlag: "--add-dir",
     modelFlag: "--model",
     maxTurnsFlag: "--max-turns",
+    // Claude Code's CLI exposes model vision, but no local-image attachment
+    // flag that OpenEval can safely pass to a headless run.
     prompt: { mode: "arg" },
-    capabilities: { supportsVisionInput: true },
     models: {
       aliases: [
         { id: "opus", label: "Opus", family: "opus", capabilities: { visionInput: true, visualCodeOutput: true } },
@@ -41,6 +42,7 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     binEnvVar: "CODEX_BIN",
     wellKnownPaths: ["~/.local/bin/codex", "~/.codex/bin/codex"],
     parser: "codex-jsonl",
+    helpArgs: ["exec", "--help"],
     argTemplate: ["exec", "--json", "--skip-git-repo-check"],
     permissionArgs: {
       bypassPermissions: ["--dangerously-bypass-approvals-and-sandbox"],
@@ -48,6 +50,7 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
       "*": ["-s", "workspace-write"],
     },
     modelFlag: "-m",
+    imageFlag: "-i",
     prompt: { mode: "arg" },
     // `codex --help` exposes `-i/--image` for both interactive and `exec`
     // modes. Cost is intentionally false because JSONL output does not report
@@ -76,8 +79,9 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     workdirFlag: "--add-dir",
     modelFlag: "--model",
     maxTurnsFlag: "--max-turns",
+    // NCode mirrors Claude Code's provider capability, but does not expose a
+    // local image flag in its headless CLI surface.
     prompt: { mode: "arg" },
-    capabilities: { supportsVisionInput: true },
     models: {
       default: "glm-5.2",
       aliases: [

--- a/lib/adapters/builtin.ts
+++ b/lib/adapters/builtin.ts
@@ -36,7 +36,7 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
   },
   {
     id: "codex",
-    label: "Codex CLI",
+    label: "Codex CLI + ChatGPT app",
     binNames: ["codex"],
     binEnvVar: "CODEX_BIN",
     wellKnownPaths: ["~/.local/bin/codex", "~/.codex/bin/codex"],

--- a/lib/adapters/discover.ts
+++ b/lib/adapters/discover.ts
@@ -30,6 +30,14 @@ export interface DiscoveredHarness {
   detail?: string;
 }
 
+/** Match the exact descriptor-declared option, including `--flag=VALUE`. */
+export function probeFlagObserved(output: string, flag: string): boolean {
+  const normalized = flag.trim();
+  if (!normalized) return false;
+  const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|[\\s,\\[])${escaped}(?=$|[\\s,=,\\]])`, "m").test(output);
+}
+
 let cache: DiscoveredHarness[] | null = null;
 
 function sampleCtx(model?: string): RunnerContext {
@@ -89,8 +97,8 @@ async function probe(adapter: HarnessAdapter): Promise<DiscoveredHarness> {
   const status: HarnessStatus = versionResult.ok && (helpResult == null || helpResult.ok) ? "available" : "error";
   const defaultModel = resolveDefaultModel(adapter.id).id;
   const sample = adapter.buildCommand(sampleCtx(defaultModel));
-  const imageFlagObserved = helpResult
-    ? /(?:^|\s)(?:--image|-i)(?:\s|,|$)/m.test(helpResult.output)
+  const imageFlagObserved = helpResult && adapter.descriptor.imageFlag
+    ? probeFlagObserved(helpResult.output, adapter.descriptor.imageFlag)
     : null;
   const failure = !versionResult.ok ? versionResult : helpResult && !helpResult.ok ? helpResult : null;
   return {

--- a/lib/adapters/discover.ts
+++ b/lib/adapters/discover.ts
@@ -1,10 +1,19 @@
 import { execFile } from "node:child_process";
-import { listAdapters, hasAdapter, getAdapter } from "./registry";
-import { expandHomePath, isExecutable, resolveOnPath } from "./generic";
+import { listAdapters, hasAdapter, getAdapter, invalidateRegistry } from "./registry";
+import { invalidateDescriptorCache } from "./loader";
+import { resolveDescriptorBinInfo } from "./generic";
 import type { AdapterCapabilities, HarnessAdapter } from "./types";
 import type { RunnerContext } from "../types";
+import { resolveDefaultModel } from "../models";
 
 export type HarnessStatus = "available" | "not_found" | "error";
+
+export interface ProbeCheck {
+  ok: boolean;
+  args: string[];
+  output?: string;
+  error?: string;
+}
 
 export interface DiscoveredHarness {
   id: string;
@@ -12,16 +21,18 @@ export interface DiscoveredHarness {
   binNames: string[];
   status: HarnessStatus;
   bin: string | null;
-  source: "path" | "well_known" | "default" | "none";
+  source: "env" | "path" | "well_known" | "default" | "none";
   version: string | null;
   capabilities: AdapterCapabilities;
-  sampleCommand?: { bin: string; args: string[] };
+  imageFlag: string | null;
+  probe?: { version: ProbeCheck; help?: ProbeCheck; imageFlagObserved: boolean | null };
+  sampleCommand?: { bin: string; args: string[]; env: Record<string, string>; stdin?: string; model?: string };
   detail?: string;
 }
 
 let cache: DiscoveredHarness[] | null = null;
 
-function sampleCtx(): RunnerContext {
+function sampleCtx(model?: string): RunnerContext {
   return {
     caseId: "<sample-case>",
     workdir: "/tmp/workdir",
@@ -29,26 +40,19 @@ function sampleCtx(): RunnerContext {
     maxTurns: 25,
     timeoutMs: 300_000,
     permissionMode: "bypassPermissions",
-    model: undefined,
+    model,
+    images: undefined,
     extraArgs: [],
   };
 }
 
-// Resolution helpers (PATH walk, well-known paths) live in generic.ts so
-// buildCommand spawns the exact binary discovery reports as "available".
+// Resolution lives in generic.ts so discovery and execution cannot disagree.
 function resolveBin(adapter: HarnessAdapter): { bin: string | null; source: DiscoveredHarness["source"] } {
-  for (const name of adapter.binNames) {
-    const onPath = resolveOnPath(name);
-    if (onPath) return { bin: onPath, source: "path" };
-  }
-  for (const candidate of adapter.wellKnownPaths ?? []) {
-    const expanded = expandHomePath(candidate);
-    if (isExecutable(expanded)) return { bin: expanded, source: "well_known" };
-  }
-  return { bin: null, source: "none" };
+  const resolved = resolveDescriptorBinInfo(adapter.descriptor);
+  return { bin: resolved.bin, source: resolved.source };
 }
 
-function runVersion(bin: string, args: string[]): Promise<{ ok: boolean; output: string; error: string }> {
+export function runProbe(bin: string, args: string[]): Promise<{ ok: boolean; output: string; error: string }> {
   return new Promise((resolve) => {
     const child = execFile(bin, args, { timeout: 6000, maxBuffer: 1 << 16 }, (err, stdout, stderr) => {
       if (err) {
@@ -74,13 +78,21 @@ async function probe(adapter: HarnessAdapter): Promise<DiscoveredHarness> {
       source: "none",
       version: null,
       capabilities: adapter.capabilities,
+      imageFlag: adapter.descriptor.imageFlag ?? null,
       detail: `No binary found on PATH or well-known paths (looked for: ${adapter.binNames.join(", ")}).`,
     };
   }
   const versionArgs = adapter.versionArgs ?? ["--version"];
-  const probe = await runVersion(bin, versionArgs);
-  const status: HarnessStatus = probe.ok ? "available" : "error";
-  const sample = adapter.buildCommand(sampleCtx());
+  const versionResult = await runProbe(bin, versionArgs);
+  const helpArgs = adapter.descriptor.helpArgs;
+  const helpResult = helpArgs.length ? await runProbe(bin, helpArgs) : null;
+  const status: HarnessStatus = versionResult.ok && (helpResult == null || helpResult.ok) ? "available" : "error";
+  const defaultModel = resolveDefaultModel(adapter.id).id;
+  const sample = adapter.buildCommand(sampleCtx(defaultModel));
+  const imageFlagObserved = helpResult
+    ? /(?:^|\s)(?:--image|-i)(?:\s|,|$)/m.test(helpResult.output)
+    : null;
+  const failure = !versionResult.ok ? versionResult : helpResult && !helpResult.ok ? helpResult : null;
   return {
     id: adapter.id,
     label: adapter.label,
@@ -88,15 +100,25 @@ async function probe(adapter: HarnessAdapter): Promise<DiscoveredHarness> {
     status,
     bin,
     source,
-    version: probe.ok ? probe.output.split("\n")[0].slice(0, 120) : null,
+    version: versionResult.ok ? versionResult.output.split("\n")[0].slice(0, 120) : null,
     capabilities: adapter.capabilities,
-    sampleCommand: { bin: sample.bin, args: sample.args },
-    detail: probe.ok ? undefined : `Binary resolved to ${bin} but \`<bin> ${versionArgs.join(" ")}\` failed: ${probe.error || "no output"}`,
+    imageFlag: adapter.descriptor.imageFlag ?? null,
+    probe: {
+      version: { args: versionArgs, ok: versionResult.ok, output: versionResult.output.slice(0, 4000) || undefined, error: versionResult.error || undefined },
+      ...(helpResult ? { help: { args: helpArgs, ok: helpResult.ok, output: helpResult.output.slice(0, 4000) || undefined, error: helpResult.error || undefined } } : {}),
+      imageFlagObserved,
+    },
+    sampleCommand: { bin: sample.bin, args: sample.args, env: sample.env, stdin: sample.stdin, ...(defaultModel ? { model: defaultModel } : {}) },
+    detail: failure ? `Binary resolved to ${bin} but \`<bin> ${(failure === versionResult ? versionArgs : helpArgs).join(" ")}\` failed: ${failure.error || "no output"}` : undefined,
   };
 }
 
 export async function discoverHarnesses(force = false): Promise<DiscoveredHarness[]> {
   if (cache && !force) return cache;
+  if (force) {
+    invalidateDescriptorCache();
+    invalidateRegistry();
+  }
   const results = await Promise.all(listAdapters().map(probe));
   cache = results;
   return results;

--- a/lib/adapters/generic.ts
+++ b/lib/adapters/generic.ts
@@ -35,6 +35,17 @@ function maybeNum(v: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+function maybeBool(v: unknown): boolean | null {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number" && Number.isFinite(v)) return v !== 0;
+  if (typeof v === "string") {
+    const normalized = v.trim().toLowerCase();
+    if (["true", "1", "yes", "y", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "n", "off", ""].includes(normalized)) return false;
+  }
+  return null;
+}
+
 /**
  * Substitution uses a replacer FUNCTION and a single pass: with plain string
  * replacement, `$&`/`` $` ``/`$'` patterns inside prompt/case text are
@@ -207,8 +218,9 @@ export function parseGenericJsonlLine(
     const id = str(getPath(obj, f.toolCallId)) || into.toolCalls[into.toolCalls.length - 1]?.id || "";
     const output = str(toolOut);
     const tc = into.toolCalls.find((t) => t.id === id);
-    if (tc) { tc.output = output; tc.isError = !!getPath(obj, f.toolCallError); }
-    events.push({ kind: "tool_result", id, output, isError: !!getPath(obj, f.toolCallError), at });
+    const isError = maybeBool(getPath(obj, f.toolCallError)) === true;
+    if (tc) { tc.output = output; tc.isError = isError; }
+    events.push({ kind: "tool_result", id, output, isError, at });
     return events;
   }
 
@@ -224,12 +236,13 @@ export function parseGenericJsonlLine(
   const inputTokens = getPath(obj, f.inputTokens);
   const outputTokens = getPath(obj, f.outputTokens);
   const isError = getPath(obj, f.isError);
+  const errorFlag = maybeBool(isError);
   if (durationMs != null || inputTokens != null || outputTokens != null || isError != null || evtType === "result" || evtType === "turn.completed" || evtType === "done") {
     const toolCallCounts: Record<string, number> = {};
     for (const tc of into.toolCalls) toolCallCounts[tc.name] = (toolCallCounts[tc.name] || 0) + 1;
     into.result = {
       ...(into.result || {}),
-      exitCode: isError ? 1 : 0,
+      exitCode: errorFlag === true ? 1 : 0,
       durationMs: maybeNum(durationMs) || (at - into.startedAt),
       startedAt: into.startedAt,
       endedAt: at,
@@ -248,7 +261,7 @@ export function parseGenericJsonlLine(
       stopReason: str(getPath(obj, f.stopReason)) || null,
       sessionId: into.result?.sessionId ?? (into as any)._lastSessionId ?? null,
       model: into.result?.model ?? (str(getPath(obj, f.model)) || null),
-      isError: !!isError,
+      isError: errorFlag === true,
       rawJson: obj,
       tokenSegments: [],
       toolCallCounts,

--- a/lib/adapters/generic.ts
+++ b/lib/adapters/generic.ts
@@ -77,6 +77,36 @@ export function resolveOnPath(bin: string): string | null {
   return null;
 }
 
+export type DescriptorBinSource = "env" | "path" | "well_known" | "default" | "none";
+
+export interface DescriptorBinResolution {
+  bin: string | null;
+  source: DescriptorBinSource;
+}
+
+/** Resolve the same binary identity that both discovery and execution use. */
+export function resolveDescriptorBinInfo(desc: NormalizedDescriptor): DescriptorBinResolution {
+  const override = desc.binEnvVar ? process.env[desc.binEnvVar]?.trim() : undefined;
+  if (override) return { bin: expandHomePath(override), source: "env" };
+
+  const names = [...new Set([desc.defaultBin, ...desc.binNames])];
+  for (const name of names) {
+    if (name.includes("/")) {
+      const expanded = expandHomePath(name);
+      if (isExecutable(expanded)) return { bin: expanded, source: name === desc.defaultBin ? "default" : "well_known" };
+      continue;
+    }
+    const onPath = resolveOnPath(name);
+    if (onPath) return { bin: onPath, source: "path" };
+  }
+
+  for (const candidate of desc.wellKnownPaths ?? []) {
+    const expanded = expandHomePath(candidate);
+    if (isExecutable(expanded)) return { bin: expanded, source: "well_known" };
+  }
+  return { bin: null, source: "none" };
+}
+
 /**
  * The binary buildCommand spawns. Resolution mirrors discovery (discover.ts):
  * env override → PATH → wellKnownPaths — previously only the env var and bare
@@ -86,17 +116,8 @@ export function resolveOnPath(bin: string): string | null {
  * fallback returns an absolute path.
  */
 export function resolveDescriptorBin(desc: NormalizedDescriptor): string {
-  if (desc.binEnvVar && process.env[desc.binEnvVar]) return process.env[desc.binEnvVar]!;
-  if (desc.defaultBin.includes("/")) return expandHomePath(desc.defaultBin);
-  if (resolveOnPath(desc.defaultBin)) return desc.defaultBin;
-  for (const name of desc.binNames) {
-    if (name !== desc.defaultBin && !name.includes("/") && resolveOnPath(name)) return name;
-  }
-  for (const candidate of desc.wellKnownPaths ?? []) {
-    const expanded = expandHomePath(candidate);
-    if (isExecutable(expanded)) return expanded;
-  }
-  return desc.defaultBin;
+  const resolved = resolveDescriptorBinInfo(desc);
+  return resolved.bin ?? desc.defaultBin;
 }
 
 /**
@@ -125,6 +146,12 @@ export function buildDescriptorCommand(desc: NormalizedDescriptor, ctx: RunnerCo
   }
   if (desc.maxTurnsFlag && ctx.maxTurns > 0 && !desc.argTemplate.some((t) => t.includes("{maxTurns}"))) {
     args.push(desc.maxTurnsFlag, String(ctx.maxTurns));
+  }
+  if (ctx.images?.length) {
+    if (!desc.imageFlag) {
+      throw new Error(`Harness "${desc.id}" does not declare a local image attachment flag`);
+    }
+    for (const image of ctx.images) args.push(desc.imageFlag, image);
   }
   if (desc.appendExtraArgs) args.push(...ctx.extraArgs);
 

--- a/lib/adapters/hermes.ts
+++ b/lib/adapters/hermes.ts
@@ -52,13 +52,18 @@ export function hermesJsonToRecords(raw: string): string[] {
   if (!doc || typeof doc !== "object" || !Array.isArray(doc.messages)) return [];
 
   const model = typeof doc.model === "string" && doc.model ? doc.model : undefined;
+  const userTurnCount = doc.messages.filter((message: HermesMessage) => message?.role === "user" && textOf(message.content).trim()).length;
   const records: unknown[] = [];
   records.push({
     type: "system",
     model,
     session_id: typeof doc.session_id === "string" ? doc.session_id : undefined,
     timestamp: doc.session_start,
+    // Hermes' message_count includes assistant/tool messages. Keep that
+    // useful raw count separate from the conversational turn count; treating
+    // every tool result as a user turn inflated Hermes turn totals badly.
     messageCount: Number(doc.message_count) || doc.messages.length,
+    turnCount: userTurnCount,
   });
 
   for (const m of doc.messages as HermesMessage[]) {

--- a/lib/adapters/hermes.ts
+++ b/lib/adapters/hermes.ts
@@ -24,6 +24,7 @@ interface HermesMessage {
   content?: unknown;
   tool_calls?: HermesToolCall[];
   tool_call_id?: string;
+  is_error?: boolean;
 }
 
 function textOf(content: unknown): string {
@@ -82,7 +83,7 @@ export function hermesJsonToRecords(raw: string): string[] {
         type: "user",
         message: {
           role: "user",
-          content: [{ type: "tool_result", tool_use_id: m.tool_call_id, content: textOf(m.content) }],
+          content: [{ type: "tool_result", tool_use_id: m.tool_call_id, content: textOf(m.content), is_error: m.is_error === true }],
         },
       });
     }

--- a/lib/adapters/schema.ts
+++ b/lib/adapters/schema.ts
@@ -59,6 +59,14 @@ const ModelAliasSchema = z
     id: z.string().min(1),
     label: z.string().min(1),
     family: z.string().min(1),
+    capabilities: z
+      .object({
+        visionInput: z.boolean().nullable().optional(),
+        visualCodeOutput: z.boolean().nullable().optional(),
+        notes: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -185,7 +193,8 @@ export interface NormalizedDescriptor {
     reportsCost: boolean;
     reportsTokens: boolean;
     reportsTurns: boolean;
-    supportsVisionInput: boolean;
+    /** null means the descriptor does not have enough evidence to claim yes/no. */
+    supportsVisionInput: boolean | null;
     permissionModes: string[];
   };
   liveTrace?: LiveTraceDescriptor;
@@ -255,7 +264,9 @@ export function normalizeDescriptor(d: z.output<typeof HarnessDescriptorSchema>)
       reportsCost: d.capabilities?.reportsCost ?? (structured || !!fields.costUsd),
       reportsTokens: d.capabilities?.reportsTokens ?? (structured || !!fields.inputTokens || !!fields.outputTokens),
       reportsTurns: d.capabilities?.reportsTurns ?? (structured || !!fields.numTurns),
-      supportsVisionInput: d.capabilities?.supportsVisionInput ?? false,
+      // An omitted vision flag is unknown, not "no". A descriptor author must
+      // provide evidence before OpenEval makes a negative capability claim.
+      supportsVisionInput: d.capabilities?.supportsVisionInput ?? null,
       permissionModes: d.capabilities?.permissionModes ?? [...PERMISSION_MODES],
     },
     liveTrace: d.liveTrace,

--- a/lib/adapters/schema.ts
+++ b/lib/adapters/schema.ts
@@ -118,6 +118,8 @@ export const HarnessDescriptorSchema = z
     binEnvVar: z.string().optional(),
     wellKnownPaths: z.array(z.string()).optional(),
     versionArgs: z.array(z.string()).optional(),
+    /** Safe, non-spending CLI probe arguments. An empty array disables help probing. */
+    helpArgs: z.array(z.string()).optional(),
 
     /** Which stdout parser to use. Falls back from legacy `output` when omitted. */
     parser: z.enum(PARSERS).optional(),
@@ -135,6 +137,8 @@ export const HarnessDescriptorSchema = z
     workdirFlag: z.string().optional(),
     modelFlag: z.string().optional(),
     maxTurnsFlag: z.string().optional(),
+    /** Repeated once per local image attachment, when a case supplies images. */
+    imageFlag: z.string().optional(),
     /** Simple form: `<permissionFlag> <mode>` is appended. */
     permissionFlag: z.string().optional(),
     /** Full form: per-mode argument lists; "*" is the fallback entry. */
@@ -177,6 +181,7 @@ export interface NormalizedDescriptor {
   binEnvVar?: string;
   wellKnownPaths?: string[];
   versionArgs: string[];
+  helpArgs: string[];
   parser: ParserKind;
   argTemplate: string[];
   extraEnv: Record<string, string>;
@@ -184,6 +189,7 @@ export interface NormalizedDescriptor {
   workdirFlag?: string;
   modelFlag?: string;
   maxTurnsFlag?: string;
+  imageFlag?: string;
   permissionFlag?: string;
   permissionArgs?: Record<string, string[]>;
   appendExtraArgs: boolean;
@@ -248,6 +254,7 @@ export function normalizeDescriptor(d: z.output<typeof HarnessDescriptorSchema>)
     binEnvVar: d.binEnvVar,
     wellKnownPaths: d.wellKnownPaths,
     versionArgs: d.versionArgs ?? ["--version"],
+    helpArgs: d.helpArgs ?? ["--help"],
     parser,
     argTemplate: d.argTemplate,
     extraEnv: d.extraEnv ?? {},
@@ -255,6 +262,7 @@ export function normalizeDescriptor(d: z.output<typeof HarnessDescriptorSchema>)
     workdirFlag: d.workdirFlag,
     modelFlag: d.modelFlag,
     maxTurnsFlag: d.maxTurnsFlag,
+    imageFlag: d.imageFlag,
     permissionFlag: d.permissionFlag,
     permissionArgs: d.permissionArgs,
     appendExtraArgs: d.appendExtraArgs ?? true,

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -2,6 +2,7 @@ import type { PermissionMode, RunnerContext, RunnerEvent, RunnerResult, Transcri
 import type { NormalizedDescriptor } from "./schema";
 
 export type HarnessId = string;
+export type CapabilityValue = boolean | null;
 
 export interface AdapterCapabilities {
   outputFormat: "stream-json" | "jsonl" | "text" | "json";
@@ -9,7 +10,8 @@ export interface AdapterCapabilities {
   reportsTokens: boolean;
   reportsTurns: boolean;
   permissionModes: PermissionMode[];
-  supportsVisionInput: boolean;
+  /** null means the descriptor does not have enough evidence to claim yes/no. */
+  supportsVisionInput: CapabilityValue;
 }
 
 export interface BuiltCommand {

--- a/lib/cases.ts
+++ b/lib/cases.ts
@@ -137,6 +137,7 @@ const SetupSchema = z
 const VisualSchema = z.object({
   kind: z.enum(["svg", "threejs", "web_ui", "app_ui", "screenshot"]),
   requires_vision_input: z.boolean().optional(),
+  input_images: z.array(z.string().min(1)).optional(),
   expected_artifacts: z.array(z.string()).optional(),
 }).strict();
 

--- a/lib/collection/conversation.ts
+++ b/lib/collection/conversation.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { hermesJsonToRecords } from "../adapters/hermes";
+import { readFileLines } from "../live";
+
+export interface ConversationMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
+const HERMES_MAX_BYTES = 32 * 1024 * 1024;
+
+function contentText(content: unknown, dropAngleBlocks = false): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((block) => {
+      if (typeof block === "string") return block;
+      if (!block || typeof block !== "object") return "";
+      const text = (block as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .filter((text) => text && !(dropAngleBlocks && text.trimStart().startsWith("<")))
+    .join(" ");
+}
+
+function messagesFromRecord(obj: Record<string, unknown>): ConversationMessage[] {
+  if ((obj as { isSidechain?: boolean }).isSidechain) return [];
+  const type = obj.type;
+  const message = obj.message as { content?: unknown } | undefined;
+
+  if (type === "user" && message && !(obj as { isMeta?: boolean }).isMeta) {
+    const text = contentText(message.content, true).trim();
+    return text && !text.startsWith("<") ? [{ role: "user", text }] : [];
+  }
+  if (type === "assistant" && message) {
+    const text = contentText(message.content).trim();
+    return text ? [{ role: "assistant", text }] : [];
+  }
+  if (type === "event_msg") {
+    const payload = obj.payload as { type?: string; message?: unknown } | undefined;
+    const text = typeof payload?.message === "string" ? payload.message.trim() : "";
+    if (payload?.type === "user_message" && text) return [{ role: "user", text }];
+    if (payload?.type === "agent_message" && text) return [{ role: "assistant", text }];
+    return [];
+  }
+  if (type === "response_item") {
+    const payload = obj.payload as { type?: string; role?: string; content?: unknown } | undefined;
+    if (payload?.type !== "message") return [];
+    const text = contentText(payload.content, payload.role === "user").trim();
+    if (!text) return [];
+    if (payload.role === "user") return [{ role: "user", text }];
+    if (payload.role === "assistant") return [{ role: "assistant", text }];
+    return [];
+  }
+  if (type === "user_msg" || type === "user_message") {
+    const payload = obj.payload as { message?: unknown; text?: unknown } | undefined;
+    const raw = payload?.message ?? payload?.text ?? obj.message ?? obj.text;
+    const text = typeof raw === "string" ? raw.trim() : "";
+    return text ? [{ role: "user", text }] : [];
+  }
+  return [];
+}
+
+function hermesRecords(file: string): string[] {
+  const stat = fs.statSync(file);
+  if (stat.size > HERMES_MAX_BYTES) return [];
+  let raw = "";
+  for (const line of readFileLines(file)) raw += line + "\n";
+  return hermesJsonToRecords(raw);
+}
+
+/** Stream normalized user/assistant prose across supported transcript formats. */
+export function* readConversationMessages(file: string): Generator<ConversationMessage> {
+  const records: Iterable<string> = path.extname(file).toLowerCase() === ".json"
+    ? hermesRecords(file)
+    : readFileLines(file);
+  const recent: ConversationMessage[] = [];
+
+  for (const line of records) {
+    if (!line.trim()) continue;
+    let obj: Record<string, unknown>;
+    try { obj = JSON.parse(line); } catch { continue; }
+    for (const message of messagesFromRecord(obj)) {
+      // New Codex rollouts echo the same turn as event_msg + response_item.
+      // Suppress only nearby protocol echoes; a genuinely repeated prompt much
+      // later in the session remains meaningful evidence.
+      if (recent.some((seen) => seen.role === message.role && seen.text === message.text)) continue;
+      yield message;
+      recent.push(message);
+      if (recent.length > 4) recent.shift();
+    }
+  }
+}

--- a/lib/collection/search.ts
+++ b/lib/collection/search.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
-import { readFileLines, listSourceFiles } from "../live";
+import { listSourceFiles } from "../live";
 import { allCollectionSources, defToSpec } from "./sources";
 import { ftsIndexedFiles, ftsUpsert, ftsSearch, type FtsHit } from "../live-cache";
 import { JUDGE_PROMPT_MARKER } from "../insights/signals";
+import { readConversationMessages } from "./conversation";
 
 /**
  * Full-text search across every parseable harness's sessions.
@@ -15,15 +16,6 @@ import { JUDGE_PROMPT_MARKER } from "../insights/signals";
 
 const TEXT_CAP = 100_000; // chars per side per session — plenty for search, bounded for the DB
 
-const textFromContent = (content: unknown): string => {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .filter((b): b is { type: string; text: string } => !!b && typeof b === "object" && (b as { type?: unknown }).type === "text" && typeof (b as { text?: unknown }).text === "string")
-    .map((b) => b.text)
-    .join(" ");
-};
-
 export interface SessionSearchText {
   userText: string;
   assistantText: string;
@@ -32,8 +24,8 @@ export interface SessionSearchText {
 
 /**
  * Pull all conversational text (user words + assistant prose, no tool noise)
- * out of a transcript, capped. Understands the Claude-projects and Codex
- * shapes; unknown shapes yield whatever text-y fields match.
+ * out of a transcript, capped. The shared conversation normalizer understands
+ * Claude, both Codex generations, and Hermes single-JSON sessions.
  */
 export function extractSearchText(file: string): SessionSearchText {
   let userText = "";
@@ -50,22 +42,9 @@ export function extractSearchText(file: string): SessionSearchText {
     }
   };
   try {
-    for (const line of readFileLines(file)) {
-      if (!line.trim()) continue;
+    for (const message of readConversationMessages(file)) {
       if (userText.length >= TEXT_CAP && assistantText.length >= TEXT_CAP) break;
-      let obj: Record<string, unknown>;
-      try { obj = JSON.parse(line); } catch { continue; }
-      const message = obj.message as { content?: unknown } | undefined;
-      if (obj.type === "user" && message && !(obj as { isMeta?: boolean }).isMeta) {
-        const t = textFromContent(message.content);
-        if (t && !t.startsWith("<")) add("u", t); // tool results arrive as "user" turns; skip tag-shaped payloads
-      } else if (obj.type === "assistant" && message) {
-        add("a", textFromContent(message.content));
-      } else if (obj.type === "event_msg") {
-        const payload = obj.payload as { type?: string; message?: unknown } | undefined;
-        if (payload?.type === "user_message" && typeof payload.message === "string") add("u", payload.message);
-        else if (payload?.type === "agent_message" && typeof payload.message === "string") add("a", payload.message);
-      }
+      add(message.role === "user" ? "u" : "a", message.text);
     }
   } catch {
     // Unreadable file → index whatever was collected (possibly nothing).

--- a/lib/collection/sources.ts
+++ b/lib/collection/sources.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { listAdapters } from "../adapters/registry";
@@ -197,7 +198,18 @@ export function isPathInAnyCollectionSource(filePath: string): boolean {
     for (const root of def.roots) {
       const base = path.resolve(expand(root));
       const rel = path.relative(base, resolved);
-      if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) return true;
+      const lexicalInside = rel && !rel.startsWith("..") && !path.isAbsolute(rel);
+      if (!lexicalInside) continue;
+      try {
+        const realBase = fs.realpathSync(base);
+        const realFile = fs.realpathSync(resolved);
+        const realRel = path.relative(realBase, realFile);
+        if (realRel && !realRel.startsWith("..") && !path.isAbsolute(realRel)) return true;
+      } catch {
+        // Preserve the pruned-file route: the caller will render the archive
+        // message after statting the path.
+        return true;
+      }
     }
   }
   return false;

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -57,6 +57,9 @@ async function copyDir(src: string, dest: string): Promise<void> {
     if (ent.name === "node_modules" || ent.name === ".git") continue;
     const s = path.join(src, ent.name);
     const d = path.join(dest, ent.name);
+    if (ent.isSymbolicLink()) {
+      throw new Error(`Fixture symlinks are not supported: ${s}`);
+    }
     if (ent.isDirectory()) {
       await fs.mkdir(d, { recursive: true });
       await copyDir(s, d);
@@ -72,6 +75,7 @@ async function resolveInputImages(def: CaseDefinition, workdir: string): Promise
     throw new Error("This case requires vision input but declares no visual.input_images");
   }
   const images: string[] = [];
+  const realWorkdir = await fs.realpath(workdir);
   for (const relative of requested) {
     if (path.isAbsolute(relative)) throw new Error(`Visual input must be relative to the case workdir: ${relative}`);
     const absolute = path.resolve(workdir, relative);
@@ -79,9 +83,15 @@ async function resolveInputImages(def: CaseDefinition, workdir: string): Promise
     if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error(`Visual input escapes the case workdir: ${relative}`);
     }
-    const stat = await fs.stat(absolute).catch(() => null);
+    const realAbsolute = await fs.realpath(absolute).catch(() => null);
+    if (!realAbsolute) throw new Error(`Visual input file is missing: ${relative}`);
+    const realRel = path.relative(realWorkdir, realAbsolute);
+    if (!realRel || realRel.startsWith("..") || path.isAbsolute(realRel)) {
+      throw new Error(`Visual input escapes the case workdir: ${relative}`);
+    }
+    const stat = await fs.stat(realAbsolute).catch(() => null);
     if (!stat?.isFile()) throw new Error(`Visual input file is missing: ${relative}`);
-    images.push(absolute);
+    images.push(realAbsolute);
   }
   return images;
 }

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -66,6 +66,26 @@ async function copyDir(src: string, dest: string): Promise<void> {
   }
 }
 
+async function resolveInputImages(def: CaseDefinition, workdir: string): Promise<string[]> {
+  const requested = def.visual?.input_images ?? [];
+  if (def.visual?.requires_vision_input && requested.length === 0) {
+    throw new Error("This case requires vision input but declares no visual.input_images");
+  }
+  const images: string[] = [];
+  for (const relative of requested) {
+    if (path.isAbsolute(relative)) throw new Error(`Visual input must be relative to the case workdir: ${relative}`);
+    const absolute = path.resolve(workdir, relative);
+    const rel = path.relative(workdir, absolute);
+    if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(`Visual input escapes the case workdir: ${relative}`);
+    }
+    const stat = await fs.stat(absolute).catch(() => null);
+    if (!stat?.isFile()) throw new Error(`Visual input file is missing: ${relative}`);
+    images.push(absolute);
+  }
+  return images;
+}
+
 function transcriptToText(r: RunnerResult): string {
   const lines: string[] = [];
   for (const m of r.transcript) {
@@ -144,6 +164,23 @@ export async function executeCase(
   const runner = getRunner(runnerKind);
   const runnerCfg = def.runner || {};
   const adapter = getAdapter(harness);
+  let images: string[];
+  try {
+    images = await resolveInputImages(def, workdir);
+    if (images.length && !adapter.descriptor.imageFlag) {
+      throw new Error(`Harness "${adapter.id}" does not declare a local image attachment flag`);
+    }
+    if (images.length && adapter.capabilities.supportsVisionInput === false) {
+      throw new Error(`Harness "${adapter.id}" does not support vision input`);
+    }
+  } catch (e: any) {
+    rec.status = "error";
+    rec.error_msg = `Vision input preparation failed: ${String(e?.message || e)}`;
+    rec.ended_at = Date.now();
+    updateRunCase(rcId, { status: rec.status, ended_at: rec.ended_at, error_msg: rec.error_msg });
+    appendEvent(runId, "case_finished", { case_id: def.id, seq, sample, status: rec.status }, def.id);
+    return rec;
+  }
   const harnessInfo = await loadHarnessInfo(harness, adapter.id);
   rec.harness_info = harnessInfo;
   const ctx = {
@@ -155,6 +192,7 @@ export async function executeCase(
     permissionMode: runnerCfg.permission_mode ?? "bypassPermissions",
     model: modelOverride || runnerCfg.model,
     extraArgs: runnerCfg.extra_args ?? [],
+    images,
     harness,
     onEvent: (ev: any) => {
       void fs.appendFile(transcriptPath, JSON.stringify(ev) + "\n").catch(() => {});

--- a/lib/grader/index.ts
+++ b/lib/grader/index.ts
@@ -6,6 +6,7 @@ import { evidenceLabel, graderEvidenceTier } from "../accuracy";
 import { appendCapped, killProcessGroup, registerProcessGroup } from "../runner/spawn";
 import { defaultJudgeModel, runJudgeBackend, extractJudgeJson, resolveJudge, validJudgeScore } from "./judge";
 import { JUDGE_PROMPT_MARKER } from "../insights/signals";
+import { resolveWithin } from "../config";
 import type { CaseEvaluation, GraderResult, GraderSpec, RunnerResult } from "../types";
 
 function runProcess(bin: string, args: string[], spec: { cwd?: string; env?: Record<string, string>; timeout_ms?: number }): Promise<{ code: number; stdout: string; stderr: string; durationMs: number; timedOut: boolean }> {
@@ -68,6 +69,39 @@ async function safeRead(p: string): Promise<string | null> {
   try { return await fs.readFile(p, "utf8"); } catch { return null; }
 }
 
+/**
+ * Resolve a grader-owned path without letting traversal or an agent-created
+ * symlink escape the evidence root. Missing files remain valid so existence
+ * and deletion graders can evaluate them honestly; their nearest existing
+ * ancestor must still resolve inside the root.
+ */
+async function resolveEvidencePath(base: string, relative: string): Promise<string | null> {
+  const candidate = resolveWithin(base, relative);
+  if (!candidate) return null;
+  const realBase = await fs.realpath(base).catch(() => null);
+  if (!realBase) return null;
+
+  let cursor = candidate;
+  let realCursor: string | null = null;
+  while (!realCursor) {
+    realCursor = await fs.realpath(cursor).catch(() => null);
+    if (realCursor) break;
+    const parent = path.dirname(cursor);
+    if (parent === cursor) return null;
+    cursor = parent;
+  }
+
+  const rel = path.relative(realBase, realCursor);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  // Existing files use their canonical path. Missing files retain the lexical
+  // candidate after their nearest existing ancestor passed the realpath check.
+  return cursor === candidate ? realCursor : candidate;
+}
+
+function escapedEvidencePath(spec: GraderSpec, relative: string, durationMs: number): GraderResult {
+  return fail(spec, `path escapes the workdir: ${relative}`, durationMs);
+}
+
 export async function runGrader(
   spec: GraderSpec,
   ctx: { workdir: string; runner: RunnerResult; transcriptText: string; fixtureSrc?: string }
@@ -96,7 +130,8 @@ export async function runGrader(
   }
 
   if (spec.type === "file_contains") {
-    const filePath = path.resolve(ctx.workdir, spec.path);
+    const filePath = await resolveEvidencePath(ctx.workdir, spec.path);
+    if (!filePath) return escapedEvidencePath(spec, spec.path, dur());
     const content = await safeRead(filePath);
     if (content === null) return fail(spec, `file not found: ${spec.path}`, dur());
     try {
@@ -112,7 +147,8 @@ export async function runGrader(
   }
 
   if (spec.type === "file_exists") {
-    const filePath = path.resolve(ctx.workdir, spec.path);
+    const filePath = await resolveEvidencePath(ctx.workdir, spec.path);
+    if (!filePath) return escapedEvidencePath(spec, spec.path, dur());
     let exists = false;
     try { await fs.access(filePath); exists = true; } catch { exists = false; }
     const passed = spec.negate ? !exists : exists;
@@ -120,7 +156,8 @@ export async function runGrader(
   }
 
   if (spec.type === "file_eq") {
-    const filePath = path.resolve(ctx.workdir, spec.path);
+    const filePath = await resolveEvidencePath(ctx.workdir, spec.path);
+    if (!filePath) return escapedEvidencePath(spec, spec.path, dur());
     const content = await safeRead(filePath);
     if (content === null) return fail(spec, `file not found: ${spec.path}`, dur());
     const actual = spec.trim ? content.trim() : content;
@@ -156,7 +193,8 @@ export async function runGrader(
   }
 
   if (spec.type === "json_path") {
-    const filePath = path.resolve(ctx.workdir, spec.path);
+    const filePath = await resolveEvidencePath(ctx.workdir, spec.path);
+    if (!filePath) return escapedEvidencePath(spec, spec.path, dur());
     const content = await safeRead(filePath);
     if (content === null) return fail(spec, `file not found: ${spec.path}`, dur());
     let parsed: any;
@@ -189,8 +227,18 @@ export async function runGrader(
     }
     const changes: string[] = [];
     for (const rel of spec.paths) {
-      const actualPath = path.resolve(ctx.workdir, rel);
-      const baselinePath = path.resolve(ctx.fixtureSrc, rel);
+      const actualPath = await resolveEvidencePath(ctx.workdir, rel);
+      if (!actualPath) {
+        changes.push(`${rel}: path escapes the workdir`);
+        continue;
+      }
+      const baselinePath = await resolveEvidencePath(ctx.fixtureSrc, rel);
+      if (!baselinePath) {
+        return {
+          ...fail(spec, `fixture path escapes the baseline root: ${rel}`, dur()),
+          infraError: true,
+        };
+      }
       const actual = await safeRead(actualPath);
       const baseline = await safeRead(baselinePath);
       if (actual === null && baseline === null) { changes.push(`${rel}: absent in both`); continue; }
@@ -205,7 +253,9 @@ export async function runGrader(
   }
 
   if (spec.type === "file_deleted") {
-    const exists = await safeRead(path.resolve(ctx.workdir, spec.path));
+    const filePath = await resolveEvidencePath(ctx.workdir, spec.path);
+    if (!filePath) return escapedEvidencePath(spec, spec.path, dur());
+    const exists = await safeRead(filePath);
     return exists === null
       ? ok(spec, `${spec.path} deleted`, dur())
       : fail(spec, `${spec.path} still exists (should be deleted)`, dur(), exists.slice(0, 200));
@@ -236,7 +286,9 @@ export async function runGrader(
 
   if (spec.type === "checksum") {
     const algo = spec.algorithm ?? "sha256";
-    const content = await safeRead(path.resolve(ctx.workdir, spec.path));
+    const filePath = await resolveEvidencePath(ctx.workdir, spec.path);
+    if (!filePath) return escapedEvidencePath(spec, spec.path, dur());
+    const content = await safeRead(filePath);
     if (content === null) return fail(spec, `file not found: ${spec.path}`, dur());
     const hash = createHash(algo).update(content).digest("hex");
     return hash === spec.expected

--- a/lib/insights/judge.ts
+++ b/lib/insights/judge.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { readFileLines } from "../live";
 import {
   extractJudgeJson,
   resolveJudge,
@@ -15,6 +14,7 @@ import {
 } from "../live-cache";
 import { JUDGE_PROMPT_MARKER } from "./signals";
 import type { SessionPoint, Marker } from "./timeline";
+import { readConversationMessages } from "../collection/conversation";
 
 // Kept for the existing public test/import surface. New code should import the
 // canonical backend module directly.
@@ -59,25 +59,13 @@ export interface JudgeDigest {
 
 const clip = (s: string, n: number) => (s.length > n ? s.slice(0, n) + "…" : s);
 
-function textFromContent(content: unknown, opts: { dropAngleBlocks?: boolean } = {}): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .filter((b): b is { type: string; text: string } => !!b && typeof b === "object" && (b as { type?: unknown }).type === "text" && typeof (b as { text?: unknown }).text === "string")
-    // User turns carry injected <system-reminder>-style blocks alongside the
-    // human's words; joining them would feed harness boilerplate to the judge.
-    .filter((b) => !(opts.dropAngleBlocks && b.text.trimStart().startsWith("<")))
-    .map((b) => b.text)
-    .join(" ");
-}
-
 /**
  * Pull just the conversational spine out of a transcript: the user's words and
  * the closing assistant message. Understands the Claude-projects shape
- * (message.content string/blocks) and the Codex shape (event_msg payloads);
- * anything else simply yields an empty digest and is skipped. Subagent
- * sidechain turns are ignored — they are the agent talking to itself, not the
- * user's judgment of the work.
+ * (message.content string/blocks), both Codex generations, and Hermes
+ * single-JSON sessions. Unknown formats yield an empty digest and are skipped.
+ * Subagent sidechain turns are ignored — they are the agent talking to itself,
+ * not the user's judgment of the work.
  */
 export function extractJudgeDigest(file: string): JudgeDigest {
   let firstUser: string | null = null;
@@ -88,31 +76,12 @@ export function extractJudgeDigest(file: string): JudgeDigest {
   };
   let lastAssistant: string | null = null;
   try {
-    for (const line of readFileLines(file)) {
-      if (!line.trim()) continue;
-      let obj: Record<string, unknown>;
-      try { obj = JSON.parse(line); } catch { continue; }
-      if ((obj as { isSidechain?: boolean }).isSidechain) continue;
-      const type = obj.type;
-      const message = obj.message as { role?: string; content?: unknown } | undefined;
-      if (type === "user" && message && !(obj as { isMeta?: boolean }).isMeta) {
-        // Tool results also arrive as "user" turns; only keep real text.
-        const text = textFromContent(message.content, { dropAngleBlocks: true }).trim();
-        if (text && !text.startsWith("<")) {
-          if (firstUser == null) firstUser = text;
-          else keepRecentUser(text);
-        }
-      } else if (type === "assistant" && message) {
-        const text = textFromContent(message.content).trim();
-        if (text) lastAssistant = text;
-      } else if (type === "event_msg") {
-        const payload = obj.payload as { type?: string; message?: unknown } | undefined;
-        if (payload?.type === "user_message" && typeof payload.message === "string" && payload.message.trim()) {
-          if (firstUser == null) firstUser = payload.message.trim();
-          else keepRecentUser(payload.message.trim());
-        } else if (payload?.type === "agent_message" && typeof payload.message === "string" && payload.message.trim()) {
-          lastAssistant = payload.message.trim();
-        }
+    for (const message of readConversationMessages(file)) {
+      if (message.role === "user") {
+        if (firstUser == null) firstUser = message.text;
+        else keepRecentUser(message.text);
+      } else {
+        lastAssistant = message.text;
       }
     }
   } catch {

--- a/lib/live-cache.ts
+++ b/lib/live-cache.ts
@@ -16,7 +16,7 @@ import type { LiveSession } from "./live";
  * Bump PARSER_VERSION whenever parseLiveSession's output changes shape or
  * semantics; stale-version rows are ignored and overwritten.
  */
-export const PARSER_VERSION = 11; // v11: unify Codex user-message normalization/marker filtering across rollout shapes; v10: sentiment lexicon and verification-tail fixes
+export const PARSER_VERSION = 12; // v12: Hermes tool-error normalization and transcript format support; v11: unify Codex user-message normalization/marker filtering across rollout shapes
 
 const CACHE_DB_PATH = path.join(ROOT, "data", "live-cache.db");
 

--- a/lib/live-cache.ts
+++ b/lib/live-cache.ts
@@ -16,7 +16,7 @@ import type { LiveSession } from "./live";
  * Bump PARSER_VERSION whenever parseLiveSession's output changes shape or
  * semantics; stale-version rows are ignored and overwritten.
  */
-export const PARSER_VERSION = 12; // v12: Hermes tool-error normalization and transcript format support; v11: unify Codex user-message normalization/marker filtering across rollout shapes
+export const PARSER_VERSION = 14; // v14: Codex turn-context/user-message turn counts; v13: accurate Hermes user-turn counts, old Codex prompt previews, and generic boolean parsing; v12: Hermes tool-error normalization and transcript format support; v11: unify Codex user-message normalization/marker filtering across rollout shapes
 
 const CACHE_DB_PATH = path.join(ROOT, "data", "live-cache.db");
 

--- a/lib/live-cache.ts
+++ b/lib/live-cache.ts
@@ -18,6 +18,9 @@ import type { LiveSession } from "./live";
  */
 export const PARSER_VERSION = 14; // v14: Codex turn-context/user-message turn counts; v13: accurate Hermes user-turn counts, old Codex prompt previews, and generic boolean parsing; v12: Hermes tool-error normalization and transcript format support; v11: unify Codex user-message normalization/marker filtering across rollout shapes
 
+/** Bump whenever transcript-to-search text extraction semantics change. */
+export const FTS_INDEX_VERSION = 1; // v1: shared Claude/Codex/Hermes conversation normalization
+
 const CACHE_DB_PATH = path.join(ROOT, "data", "live-cache.db");
 
 let db: Database.Database | null = null;
@@ -41,6 +44,9 @@ function getCacheDb(): Database.Database | null {
     // Additive migration: remember each file's fts rowid so re-indexing can
     // delete by rowid instead of scanning the UNINDEXED `file` column.
     try { conn.exec("ALTER TABLE fts_meta ADD COLUMN fts_rowid INTEGER"); } catch {}
+    // Text extraction evolves independently from the live-session parser.
+    // Old rows must be offered to the explicit indexer again after a change.
+    try { conn.exec("ALTER TABLE fts_meta ADD COLUMN index_version INTEGER NOT NULL DEFAULT 0"); } catch {}
     db = conn;
     return conn;
   } catch {
@@ -84,7 +90,8 @@ CREATE TABLE IF NOT EXISTS fts_meta (
   mtime_ms REAL NOT NULL,
   size INTEGER NOT NULL,
   indexed_at INTEGER NOT NULL,
-  fts_rowid INTEGER
+  fts_rowid INTEGER,
+  index_version INTEGER NOT NULL DEFAULT 0
 );
 `;
 
@@ -295,7 +302,7 @@ export function ftsIndexedFiles(): Map<string, { mtimeMs: number; size: number }
   const conn = getCacheDb();
   if (!conn) return out;
   try {
-    for (const r of conn.prepare("SELECT file, mtime_ms, size FROM fts_meta").all() as Array<{ file: string; mtime_ms: number; size: number }>) {
+    for (const r of conn.prepare("SELECT file, mtime_ms, size FROM fts_meta WHERE index_version = ?").all(FTS_INDEX_VERSION) as Array<{ file: string; mtime_ms: number; size: number }>) {
       out.set(r.file, { mtimeMs: r.mtime_ms, size: r.size });
     }
   } catch {}
@@ -322,11 +329,12 @@ export function ftsUpsert(doc: FtsDoc, mtimeMs: number, size: number): void {
         .run(doc.userText, doc.assistantText, doc.title, doc.project, doc.sourceId, doc.file, doc.at);
       conn
         .prepare(
-          `INSERT INTO fts_meta (file, mtime_ms, size, indexed_at, fts_rowid) VALUES (?, ?, ?, ?, ?)
+          `INSERT INTO fts_meta (file, mtime_ms, size, indexed_at, fts_rowid, index_version) VALUES (?, ?, ?, ?, ?, ?)
            ON CONFLICT(file) DO UPDATE SET mtime_ms = excluded.mtime_ms, size = excluded.size,
-             indexed_at = excluded.indexed_at, fts_rowid = excluded.fts_rowid`,
+             indexed_at = excluded.indexed_at, fts_rowid = excluded.fts_rowid,
+             index_version = excluded.index_version`,
         )
-        .run(doc.file, mtimeMs, size, Date.now(), Number(inserted.lastInsertRowid));
+        .run(doc.file, mtimeMs, size, Date.now(), Number(inserted.lastInsertRowid), FTS_INDEX_VERSION);
     });
     tx();
   } catch {}

--- a/lib/live.ts
+++ b/lib/live.ts
@@ -342,8 +342,24 @@ export function isPathInLiveSource(filePath: string, harness?: string): boolean 
   return source.roots.some((root) => {
     const rootPath = path.resolve(root);
     const rel = path.relative(rootPath, resolved);
-    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+    const lexicalInside = rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+    if (!lexicalInside) return false;
+    try {
+      const realRoot = fs.realpathSync(rootPath);
+      const realFile = fs.realpathSync(resolved);
+      const realRel = path.relative(realRoot, realFile);
+      return realRel === "" || (!realRel.startsWith("..") && !path.isAbsolute(realRel));
+    } catch {
+      // A pruned/missing transcript can still be opened as an archived-path
+      // diagnostic. The later stat/parse step reports its disappearance.
+      return true;
+    }
   });
+}
+
+/** Expose the selected source format to server actions that open transcripts. */
+export function liveTraceFormatForHarness(harness?: string): LiveTraceFormat {
+  return resolveLiveSource(harness).format;
 }
 
 function decodeProjectDir(name: string): string {
@@ -618,36 +634,54 @@ function collectJsonlRecursive(
 
 const TRANSCRIPT_TURN_CAP = 20_000;
 
-export function parseSessionTranscript(filePath: string): TranscriptResult {
-  try {
-    const turns: LiveTranscriptTurn[] = [];
-    let index = 0;
-    // Stream (don't readFileSync a giant string) and cap turns so a multi-hundred-MB
-    // session can be opened without exhausting memory.
-    for (const line of readFileLines(filePath)) {
-      if (!line.trim()) continue;
-      index++;
-      try {
-        turns.push(toTranscriptTurn(JSON.parse(line), index));
-      } catch {
-        turns.push({
-          type: "malformed",
-          severity: "warning",
-          label: `Malformed line ${index}`,
-          preview: line.slice(0, 420),
-        });
-      }
-      if (turns.length >= TRANSCRIPT_TURN_CAP) {
-        turns.push({
-          type: "truncated",
-          severity: "info",
-          label: `Transcript truncated at ${TRANSCRIPT_TURN_CAP} lines`,
-          preview: "This session is very large; earlier lines are shown.",
-        });
-        break;
-      }
+const HERMES_TRANSCRIPT_MAX_BYTES = 32 * 1024 * 1024;
+
+function parseTranscriptRecords(records: Iterable<string>): TranscriptResult {
+  const turns: LiveTranscriptTurn[] = [];
+  let index = 0;
+  for (const line of records) {
+    if (!line.trim()) continue;
+    index++;
+    try {
+      turns.push(toTranscriptTurn(JSON.parse(line), index));
+    } catch {
+      turns.push({
+        type: "malformed",
+        severity: "warning",
+        label: `Malformed line ${index}`,
+        preview: line.slice(0, 420),
+      });
     }
-    return { turns };
+    if (turns.length >= TRANSCRIPT_TURN_CAP) {
+      turns.push({
+        type: "truncated",
+        severity: "info",
+        label: `Transcript truncated at ${TRANSCRIPT_TURN_CAP} lines`,
+        preview: "This session is very large; earlier lines are shown.",
+      });
+      break;
+    }
+  }
+  return { turns };
+}
+
+export function parseSessionTranscript(filePath: string, format?: LiveTraceFormat): TranscriptResult {
+  try {
+    const isHermes = format === "hermes-json" || path.extname(filePath).toLowerCase() === ".json";
+    if (isHermes) {
+      const stat = fs.statSync(filePath);
+      if (stat.size > HERMES_TRANSCRIPT_MAX_BYTES) {
+        return { turns: [], error: `Hermes transcript exceeds the ${HERMES_TRANSCRIPT_MAX_BYTES / (1024 * 1024)} MiB viewer limit` };
+      }
+      let raw = "";
+      for (const line of readFileLines(filePath)) raw += line + "\n";
+      const records = hermesJsonToRecords(raw);
+      if (records.length === 0) return { turns: [], error: "Unsupported single-JSON transcript format" };
+      return parseTranscriptRecords(records);
+    }
+    // Stream (don't readFileSync a giant string) and cap turns so a multi-hundred-MB
+    // JSONL session can be opened without exhausting memory.
+    return parseTranscriptRecords(readFileLines(filePath));
   } catch (e) {
     return { turns: [], error: e instanceof Error ? e.message : String(e) };
   }
@@ -657,8 +691,8 @@ function isErroringTurn(turn: LiveTranscriptTurn): boolean {
   return turn.severity === "error" || turn.severity === "warning";
 }
 
-export function getErroringTurns(filePath: string): TranscriptResult {
-  const parsed = parseSessionTranscript(filePath);
+export function getErroringTurns(filePath: string, format?: LiveTraceFormat): TranscriptResult {
+  const parsed = parseSessionTranscript(filePath, format);
   if (parsed.error) return { turns: [], error: parsed.error };
   const keep = new Set<number>();
   parsed.turns.forEach((turn, index) => {

--- a/lib/live.ts
+++ b/lib/live.ts
@@ -494,10 +494,27 @@ function parseSourceSessionList(source: LiveTraceSource, limit: number, scanWarn
       : source.format === "hermes-json"
         ? summarizeHermesSessionFile(f.file, f.project, f.mtime)
         : summarizeLiveSessionFile(f.file, f.project, f.mtime, { fields: source.fields, inferredModel: source.inferredModel, decodeProject: source.format !== "jsonl-dir" });
-    if (s) sessions.push(s);
+    if (s) {
+      // Codex/ChatGPT rotates older rollouts into a dedicated on-disk archive.
+      // Those files are still live-readable, but must retain archive provenance
+      // so Collection totals and the UI do not confuse them with active-root
+      // transcripts. Pruned files are marked below by appendArchivedSessions.
+      const archivedOnDisk = source.format === "codex-sessions" && isUnderNamedRoot(f.file, source.roots, "archived_sessions");
+      sessions.push(archivedOnDisk ? { ...s, archived: true } : s);
+    }
   }
   if (includeArchived) appendArchivedSessions(source, sessions);
   return sessions;
+}
+
+function isUnderNamedRoot(file: string, roots: string[], name: string): boolean {
+  const resolvedFile = path.resolve(file);
+  return roots.some((root) => {
+    if (path.basename(path.resolve(root)) !== name) return false;
+    const resolvedRoot = path.resolve(root);
+    const rel = path.relative(resolvedRoot, resolvedFile);
+    return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+  });
 }
 
 /**

--- a/lib/live.ts
+++ b/lib/live.ts
@@ -833,6 +833,8 @@ function parseLiveSession(file: string, lines: Iterable<string>, bytes: number, 
   let durationMs = 0;
   let stopReason: string | null = null;
   let isError = false;
+  let declaredTurnCount: number | null = null;
+  let turnInferenceSource: "messageCount" | "userMessages" | undefined;
   let startedAt = mtime;
   let lastEventAt = mtime;
   let pathBytes = 0;
@@ -942,6 +944,7 @@ function parseLiveSession(file: string, lines: Iterable<string>, bytes: number, 
         stopReason = obj.stopReason ?? stopReason;
         hookErrors += Number(obj.hookErrors ?? 0) || 0;
         messageCount = Math.max(messageCount, Number(obj.messageCount ?? 0) || 0);
+        if (Number.isFinite(Number(obj.turnCount))) declaredTurnCount = Math.max(0, Number(obj.turnCount));
         if (typeof obj.durationMs === "number") {
           durationMs = Math.max(durationMs, obj.durationMs);
           metricSources.duration = "measured";
@@ -1099,8 +1102,8 @@ function parseLiveSession(file: string, lines: Iterable<string>, bytes: number, 
           metricSources.turns = "measured";
         }
         stopReason = coalesceString(getPath(obj, f.stopReason), stopReason);
-        const genericError = getPath(obj, f.isError);
-        if (genericError != null) isError = Boolean(genericError);
+        const genericError = booleanOrNull(getPath(obj, f.isError));
+        if (genericError != null) isError = genericError;
       }
     }
   } catch {
@@ -1113,16 +1116,23 @@ function parseLiveSession(file: string, lines: Iterable<string>, bytes: number, 
     model = inferredModel;
     metricSources.model = "inferred";
   }
-  if (numTurns === 0 && messageCount > 0) {
+  if (numTurns === 0 && declaredTurnCount != null) {
+    numTurns = declaredTurnCount;
+    metricSources.turns = "inferred";
+    turnInferenceSource = "userMessages";
+  } else if (numTurns === 0 && messageCount > 0) {
     numTurns = messageCount;
     metricSources.turns = "inferred";
+    turnInferenceSource = "messageCount";
   } else if (numTurns === 0 && userTextTurns > 0) {
     // Interactive sessions carry no result/messageCount record; the count of
     // real (non-sidechain, non-injected) user prompts is the honest fallback.
     numTurns = userTextTurns;
     metricSources.turns = "inferred";
+    turnInferenceSource = "userMessages";
   } else if (numTurns > 0 && metricSources.turns === "missing") {
     metricSources.turns = sawResult ? "measured" : "inferred";
+    turnInferenceSource = "messageCount";
   }
   // Interactive sessions also lack duration records, but nearly every record
   // carries a timestamp — infer the observed span rather than reporting 0
@@ -1148,7 +1158,7 @@ function parseLiveSession(file: string, lines: Iterable<string>, bytes: number, 
     }
   }
 
-  const parseWarnings = buildWarnings(metricSources, malformedLineCount, lineCount, hookErrors, sawResult, model);
+  const parseWarnings = buildWarnings(metricSources, malformedLineCount, lineCount, hookErrors, sawResult, model, turnInferenceSource);
   const toolErrorRate = toolCalls > 0 ? toolErrors / toolCalls : 0;
   const toolCallsPerTurn = numTurns > 0 ? toolCalls / numTurns : 0;
   const textAvailability = lineCount > 0 ? textBlocks / lineCount : 0;
@@ -1298,6 +1308,9 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
   let toolCalls = 0;
   let toolErrors = 0;
   let messageCount = 0;
+  let turnContextCount = 0;
+  let eventUserMessageCount = 0;
+  let responseUserMessageCount = 0;
   let textBlocks = 0;
   let thinkingBlocks = 0;
   let startedAt = mtime;
@@ -1372,6 +1385,7 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
         displayTitle = displayTitle ?? payload.thread_name ?? null;
         if (payload.model || payload.model_slug) metricSources.model = "measured";
       } else if (obj.type === "turn_context") {
+        turnContextCount++;
         const payload = obj.payload ?? {};
         project = payload.cwd ?? project;
         displayTitle = displayTitle ?? payload.thread_name ?? payload.title ?? null;
@@ -1392,7 +1406,9 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
           // Real rollouts carry user text HERE (event_msg/user_message), never
           // as a top-level user_msg record — this branch feeds the preview,
           // title fallback, and sentiment/rephrase signals for Codex sessions.
-          if (recordCodexUserText(payload.message) === "judge") return null;
+          const recorded = recordCodexUserText(payload.message);
+          if (recorded === "judge") return null;
+          if (recorded === "recorded") eventUserMessageCount++;
         } else if (payload.type === "token_count") {
           const info = payload.info ?? {};
           const last = info.last_token_usage;
@@ -1434,9 +1450,10 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
           const text = Array.isArray(payload.content)
             ? payload.content.map((item: any) => item.text).filter(Boolean).join(" ")
             : "";
+          if (payload.role === "user") responseUserMessageCount++;
           // OpenEval's own CLI-backed judge invocations leave codex_exec stub
           // sessions behind; they are instrumentation, not user work.
-          if (payload.role === "user" && text.trim().startsWith(JUDGE_PROMPT_MARKER)) return null;
+          if (payload.role === "user" && !lastPromptPreview && recordCodexUserText(text) === "judge") return null;
           // Injected wrappers ("<permissions instructions>", "<environment_context>")
           // and orchestrator persona preambles make useless titles — wait for
           // the first real message.
@@ -1513,7 +1530,12 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
     metricSources.cost = "inferred";
   }
 
-  const parseWarnings = buildWarnings(metricSources, malformedLineCount, lineCount, 0, true);
+  const turnInferenceSource: "turnContext" | "userMessages" | "messageCount" = turnContextCount > 0
+    ? "turnContext"
+    : Math.max(responseUserMessageCount, eventUserMessageCount) > 0
+      ? "userMessages"
+      : "messageCount";
+  const parseWarnings = buildWarnings(metricSources, malformedLineCount, lineCount, 0, true, model, turnInferenceSource);
   if (originator) parseWarnings.push(`source: ${originator}${source ? ` / ${source}` : ""}${cliVersion ? ` ${cliVersion}` : ""}`);
   const toolErrorRate = toolCalls > 0 ? toolErrors / toolCalls : 0;
 
@@ -1535,7 +1557,12 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
     usageSegments: downsampleUsageSegments(usageSegments),
     toolCalls,
     toolErrors,
-    numTurns: Math.max(messageCount, 1),
+    numTurns: Math.max(
+      turnContextCount > 0
+        ? turnContextCount
+        : Math.max(responseUserMessageCount, eventUserMessageCount),
+      1,
+    ),
     stopReason: null,
     isError: toolErrors > 0,
     pathBytes,
@@ -1554,7 +1581,9 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
     metricSources,
     parseWarnings,
     toolErrorRate,
-    toolCallsPerTurn: messageCount > 0 ? toolCalls / messageCount : toolCalls,
+    toolCallsPerTurn: turnContextCount > 0 || responseUserMessageCount > 0 || eventUserMessageCount > 0
+      ? toolCalls / Math.max(turnContextCount, responseUserMessageCount, eventUserMessageCount)
+      : toolCalls,
     textAvailability: lineCount > 0 ? textBlocks / lineCount : 0,
     staleMs: Math.max(0, Date.now() - lastEventAt),
     traceGraph: {
@@ -1591,14 +1620,29 @@ function parseCodexSession(file: string, lines: Iterable<string>, bytes: number,
   };
 }
 
-function buildWarnings(sources: LiveMetricSources, malformedLineCount: number, lineCount: number, hookErrors: number, sawResult: boolean, model?: string | null): string[] {
+function buildWarnings(
+  sources: LiveMetricSources,
+  malformedLineCount: number,
+  lineCount: number,
+  hookErrors: number,
+  sawResult: boolean,
+  model?: string | null,
+  turnInferenceSource?: "messageCount" | "userMessages" | "turnContext",
+): string[] {
   const warnings: string[] = [];
   if (sources.model === "missing") warnings.push("model missing from trace");
   if (sources.model === "inferred") warnings.push(`model inferred as ${model ?? "unknown"} from the harness descriptor's liveTrace default`);
   if (sources.tokens === "missing") warnings.push("token usage missing from trace");
   if (sources.cost === "missing") warnings.push("cost missing from trace");
   if (sources.duration === "missing") warnings.push("duration missing from trace");
-  if (sources.turns === "inferred") warnings.push("turn count inferred from messageCount");
+  if (sources.turns === "inferred") {
+    const label = turnInferenceSource === "userMessages"
+      ? "user messages"
+      : turnInferenceSource === "turnContext"
+        ? "turn context records"
+        : "messageCount";
+    warnings.push(`turn count inferred from ${label}`);
+  }
   if (!sawResult) warnings.push("no final result event found");
   if (malformedLineCount > 0) warnings.push(`${malformedLineCount}/${lineCount} malformed line(s) skipped`);
   if (hookErrors > 0) warnings.push(`${hookErrors} hook error(s) reported`);
@@ -1614,6 +1658,17 @@ function coalesceString(value: unknown, fallback: string | null): string | null 
 function numericOrNull(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
+}
+
+function booleanOrNull(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "y", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "n", "off", ""].includes(normalized)) return false;
+  }
+  return null;
 }
 
 /**

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -43,7 +43,7 @@ function execGit(args: string[]): Promise<string | null> {
 export async function collectRunManifest(
   harnessId: string,
   model?: string,
-  opts?: { harnessWasDefault?: boolean; modelWasDefault?: boolean }
+  opts?: { harnessWasDefault?: boolean; modelWasDefault?: boolean; modelDefaultSource?: "descriptor" | "config" | "none" }
 ): Promise<RunManifest> {
   const [openevalVersion, harnessProbe, gitSha, gitBranch, gitStatus] = await Promise.all([
     readOpenEvalVersion(),
@@ -61,7 +61,7 @@ export async function collectRunManifest(
   })();
   const defaultsApplied: string[] = [];
   if (opts?.harnessWasDefault) defaultsApplied.push(`harness:${harnessId} (registry default)`);
-  if (opts?.modelWasDefault && model) defaultsApplied.push(`model:${model} (adapter default)`);
+  if (opts?.modelWasDefault && model) defaultsApplied.push(`model:${model} (${opts.modelDefaultSource === "config" ? "local config" : opts.modelDefaultSource === "descriptor" ? "descriptor" : "harness default"})`);
 
   return {
     openevalVersion,

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -240,6 +240,9 @@ export function discoverModels(harnessId?: string): ModelInfo[] {
 }
 
 export function isValidModelId(id: string | undefined | null): boolean {
-  if (!id) return false;
-  return true;
+  if (typeof id !== "string") return false;
+  const normalized = id.trim();
+  // Custom provider ids are intentionally allowed, but never accept control
+  // characters or an unbounded value that could poison command/API surfaces.
+  return normalized.length > 0 && normalized.length <= 200 && !/[\u0000-\u001f\u007f]/.test(normalized);
 }

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -11,8 +11,9 @@ export interface ModelInfo {
   source: "config" | "alias" | "default";
   contextWindow?: number;
   capabilities: {
-    visionInput: boolean;
-    visualCodeOutput: boolean;
+    /** null means this model's capability is not proven by local metadata. */
+    visionInput: boolean | null;
+    visualCodeOutput: boolean | null;
     notes?: string;
   };
   isAlias?: boolean;
@@ -39,23 +40,34 @@ function labelFromId(id: string): string {
   return noSuffix.replace(/[-_]/g, " ").replace(/\s+/g, " ").trim();
 }
 
-function capabilitiesForFamily(family: string, id: string): ModelInfo["capabilities"] {
+function capabilitiesForFamily(family: string, id: string, harnessSupportsVision: boolean | null): ModelInfo["capabilities"] {
   const l = id.toLowerCase();
-  if (family === "glm") {
-    return {
-      visionInput: false,
-      visualCodeOutput: true,
-      notes: "Text-only model; still suitable for SVG, Three.js, web UI, and app UI generation tasks.",
-    };
-  }
   if (family === "gemini" || l.includes("vision") || l.includes("multimodal")) {
     return { visionInput: true, visualCodeOutput: true };
   }
-  return { visionInput: false, visualCodeOutput: true };
+  // The harness can prove that it accepts image attachments, but that does
+  // not prove every arbitrary configured model accepts them. Model-specific
+  // metadata or an explicit alias declaration is required for "vision".
+  return {
+    visionInput: null,
+    visualCodeOutput: true,
+    notes: harnessSupportsVision === true
+      ? "This harness accepts image attachments; model-specific image support is not declared locally."
+      : "Model-specific image support is not declared locally.",
+  };
 }
 
-function modelInfo(input: Omit<ModelInfo, "capabilities">): ModelInfo {
-  return { ...input, capabilities: capabilitiesForFamily(input.family, input.id) };
+type ModelCapabilityOverrides = Partial<ModelInfo["capabilities"]>;
+
+function modelInfo(
+  input: Omit<ModelInfo, "capabilities"> & { capabilities?: ModelCapabilityOverrides },
+  harnessSupportsVision: boolean | null,
+): ModelInfo {
+  const { capabilities, ...rest } = input;
+  return {
+    ...rest,
+    capabilities: { ...capabilitiesForFamily(input.family, input.id, harnessSupportsVision), ...capabilities },
+  };
 }
 
 function expandHome(p: string): string {
@@ -81,13 +93,55 @@ function collectAtPath(obj: unknown, parts: string[]): unknown[] {
 
 const cache = new Map<string, ModelInfo[]>();
 
+function configuredModelIds(harnessId: string): string[] {
+  if (harnessId === "codex") {
+    const file = expandHome("~/.codex/config.toml");
+    try {
+      const text = fs.readFileSync(file, "utf8");
+      return [...text.matchAll(/^\s*model\s*=\s*["']([^"']+)["']\s*$/gm)].map((m) => m[1]);
+    } catch {}
+  }
+  if (harnessId === "hermes") {
+    const file = expandHome("~/.hermes/config.yaml");
+    try {
+      const text = fs.readFileSync(file, "utf8");
+      const match = text.match(/^\s+default:\s*([^#\s]+)\s*$/m);
+      return match ? [match[1]] : [];
+    } catch {}
+  }
+  return [];
+}
+
+export function configuredDefaultModel(harnessId: string): string | undefined {
+  if (harnessId === "codex") {
+    const file = expandHome("~/.codex/config.toml");
+    try {
+      const text = fs.readFileSync(file, "utf8");
+      // The first root-level model assignment is Codex's active default;
+      // profile assignments below it are alternatives, not the default.
+      return text.match(/^model\s*=\s*["']([^"']+)["']\s*$/m)?.[1];
+    } catch {}
+  }
+  if (harnessId === "hermes") {
+    const file = expandHome("~/.hermes/config.yaml");
+    try {
+      const text = fs.readFileSync(file, "utf8");
+      return text.match(/^\s+default:\s*([^#\s]+)\s*$/m)?.[1];
+    } catch {}
+  }
+  return undefined;
+}
+
 /**
  * Models offered for a harness come from its descriptor: a static alias list
  * plus optional discovery of previously-used model ids from a local config
  * file. Nothing here is harness-specific code — it's all descriptor data.
  */
 export function discoverModels(harnessId?: string): ModelInfo[] {
-  const key = harnessId && hasAdapter(harnessId) ? harnessId : "*";
+  // An explicit unknown harness must not silently receive another harness's
+  // model catalog. That made `/api/models?harness=typo` look valid.
+  if (harnessId && !hasAdapter(harnessId)) return [];
+  const key = harnessId || "*";
   const hit = cache.get(key);
   if (hit) return hit;
 
@@ -96,15 +150,22 @@ export function discoverModels(harnessId?: string): ModelInfo[] {
 
   for (const adapter of adapters) {
     const models = adapter.descriptor.models;
-    if (!models) continue;
+    const harnessSupportsVision = adapter.capabilities.supportsVisionInput;
 
-    for (const a of models.aliases ?? []) {
+    for (const a of models?.aliases ?? []) {
       if (!found.has(a.id)) {
-        found.set(a.id, modelInfo({ id: a.id, label: a.label, family: a.family, source: "alias", isAlias: true }));
+        found.set(a.id, modelInfo({
+          id: a.id,
+          label: a.label,
+          family: a.family,
+          source: "alias",
+          isAlias: true,
+          capabilities: a.capabilities,
+        }, harnessSupportsVision));
       }
     }
 
-    const discovery = models.discovery;
+    const discovery = models?.discovery;
     if (discovery) {
       const file = expandHome(discovery.file);
       if (fs.existsSync(file)) {
@@ -121,20 +182,31 @@ export function discoverModels(harnessId?: string): ModelInfo[] {
                 family: familyFromId(modelId),
                 source: "config",
                 contextWindow: typeof s.contextWindow === "number" ? s.contextWindow : undefined,
-              }));
+              }, harnessSupportsVision));
             }
           }
         } catch {}
       }
     }
 
-    if (models.default && !found.has(models.default)) {
+    for (const modelId of configuredModelIds(adapter.id)) {
+      if (!found.has(modelId)) {
+        found.set(modelId, modelInfo({
+          id: modelId,
+          label: labelFromId(modelId),
+          family: familyFromId(modelId),
+          source: "config",
+        }, harnessSupportsVision));
+      }
+    }
+
+    if (models?.default && !found.has(models.default)) {
       found.set(models.default, modelInfo({
         id: models.default,
         label: labelFromId(models.default),
         family: familyFromId(models.default),
         source: "default",
-      }));
+      }, harnessSupportsVision));
     }
   }
 

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -19,6 +19,13 @@ export interface ModelInfo {
   isAlias?: boolean;
 }
 
+export type ModelDefaultSource = "descriptor" | "config" | "none";
+
+export interface ResolvedModelDefault {
+  id?: string;
+  source: ModelDefaultSource;
+}
+
 function familyFromId(id: string): string {
   const l = id.toLowerCase();
   if (l.includes("glm")) return "glm";
@@ -50,11 +57,21 @@ function capabilitiesForFamily(family: string, id: string, harnessSupportsVision
   // metadata or an explicit alias declaration is required for "vision".
   return {
     visionInput: null,
-    visualCodeOutput: true,
+    visualCodeOutput: null,
     notes: harnessSupportsVision === true
       ? "This harness accepts image attachments; model-specific image support is not declared locally."
       : "Model-specific image support is not declared locally.",
   };
+}
+
+/** Resolve the model that a run should record when the caller leaves it blank. */
+export function resolveDefaultModel(harnessId: string): ResolvedModelDefault {
+  if (!hasAdapter(harnessId)) return { source: "none" };
+  const descriptorDefault = getAdapter(harnessId).descriptor.models?.default;
+  if (descriptorDefault) return { id: descriptorDefault, source: "descriptor" };
+  const configured = configuredDefaultModel(harnessId);
+  if (configured) return { id: configured, source: "config" };
+  return { source: "none" };
 }
 
 type ModelCapabilityOverrides = Partial<ModelInfo["capabilities"]>;

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -6,10 +6,11 @@ import { appendEvent, getLastEventAt, getRun, getRunCaseBySeq, getRunStatus, ins
 import { executeCase } from "./executor";
 import { computeSummary } from "./summary";
 import { selectCases } from "./cases";
-import { getAdapter, getDefaultHarness } from "./adapters/registry";
+import { getDefaultHarness } from "./adapters/registry";
 import { collectRunManifest } from "./manifest";
 import type { CaseDefinition, RunnerKind } from "./types";
 import { isTerminalCaseStatus } from "./status";
+import { resolveDefaultModel } from "./models";
 
 // In-process cancellation fast path. The run row's status in SQLite is the
 // source of truth — dev HMR can reset this module (and this Map) mid-run, so
@@ -39,7 +40,8 @@ export async function createAndStartRun(params: CreateRunParams): Promise<{ id: 
   if (cases.length === 0) throw new Error("No cases match the filter");
   const samples = Math.max(1, Math.min(params.samples ?? 1, 8));
   const harness = params.harness || getDefaultHarness();
-  const model = params.model || getAdapter(harness).descriptor.models?.default;
+  const resolvedDefault = resolveDefaultModel(harness);
+  const model = params.model || resolvedDefault.id;
 
   const run = {
     id,
@@ -51,7 +53,7 @@ export async function createAndStartRun(params: CreateRunParams): Promise<{ id: 
     summary: null,
   };
   insertRun(run);
-  void collectRunManifest(harness, model, { harnessWasDefault: !params.harness, modelWasDefault: !params.model })
+  void collectRunManifest(harness, model, { harnessWasDefault: !params.harness, modelWasDefault: !params.model, modelDefaultSource: resolvedDefault.source })
     .then((m) => updateRunManifest(id, m))
     .catch(() => {});
   appendEvent(id, "run_started", { case_count: cases.length, samples, runner: params.runner, harness, model }, undefined);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,6 +67,8 @@ export interface CaseDefinition {
   visual?: {
     kind: "svg" | "threejs" | "web_ui" | "app_ui" | "screenshot";
     requires_vision_input?: boolean;
+    /** Paths relative to the prepared workdir that should be attached to the initial prompt. */
+    input_images?: string[];
     expected_artifacts?: string[];
   };
   graders: GraderSpec[];
@@ -84,6 +86,8 @@ export interface RunnerContext {
   permissionMode: PermissionMode;
   model?: string;
   extraArgs: string[];
+  /** Absolute local image paths attached to the initial prompt when supported by the harness. */
+  images?: string[];
   harness?: string;
   onEvent?: (event: RunnerEvent) => void;
 }

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -209,3 +209,23 @@ test("GET artifact serves files only from the case workdir", async () => {
   );
   assert.equal(escaped.status, 400);
 });
+
+test("GET artifact rejects symlinks that escape the case workdir", async () => {
+  const { artifactRoute, db } = await importRoutes();
+  const run = makeRun({ status: "completed", ended_at: Date.now() });
+  const workdir = path.join(tempRoot, "workdir-symlink");
+  const outside = path.join(tempRoot, "outside-secret.txt");
+  fs.mkdirSync(workdir, { recursive: true });
+  fs.writeFileSync(outside, "must not be served");
+  fs.symlinkSync(outside, path.join(workdir, "escaped.txt"));
+  db.insertRun(run);
+  db.insertRunCase(makeRunCase(run.id, 1, { workdir_path: workdir }));
+
+  const escaped = await artifactRoute.GET(
+    new NextRequest(`http://localhost:3000/api/runs/${run.id}/case/case-1/artifact?path=escaped.txt`),
+    { params: Promise.resolve({ id: run.id, caseId: "case-1" }) },
+  );
+
+  assert.equal(escaped.status, 400);
+  assert.match((await escaped.json()).error, /invalid path/i);
+});

--- a/tests/collection-search.test.ts
+++ b/tests/collection-search.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { extractSearchText } from "../lib/collection/search";
+
+function tempFile(name: string, content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-search-test-"));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+test("extractSearchText indexes legacy Codex response_item messages", () => {
+  const file = tempFile("codex.jsonl", [
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "repair the ledger totals" }] } },
+    { type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "The ledger now balances." }] } },
+  ].map((record) => JSON.stringify(record)).join("\n"));
+
+  assert.deepEqual(extractSearchText(file), {
+    userText: "repair the ledger totals",
+    assistantText: "The ledger now balances.",
+    title: "repair the ledger totals",
+  });
+});
+
+test("extractSearchText indexes Hermes single-JSON conversations", () => {
+  const file = tempFile("hermes.json", JSON.stringify({
+    session_id: "hermes-search",
+    messages: [
+      { role: "user", content: "trace the missing invoice" },
+      { role: "assistant", content: "The invoice was restored." },
+      { role: "tool", content: "internal tool noise" },
+    ],
+  }, null, 2));
+
+  assert.deepEqual(extractSearchText(file), {
+    userText: "trace the missing invoice",
+    assistantText: "The invoice was restored.",
+    title: "trace the missing invoice",
+  });
+});

--- a/tests/collection.test.ts
+++ b/tests/collection.test.ts
@@ -151,6 +151,32 @@ test("scanSourceSessions keeps archived sessions after their files are pruned", 
   }
 });
 
+test("scanSourceSessions marks Codex rollouts in archived_sessions as archived", () => {
+  const active = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-codex-active-"));
+  const archiveParent = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-codex-archive-"));
+  const archive = path.join(archiveParent, "archived_sessions");
+  fs.mkdirSync(archive);
+  const writeCodex = (dir: string, id: string) => fs.writeFileSync(path.join(dir, `rollout-${id}.jsonl`), [
+    { type: "session_meta", payload: { id, cwd: "/tmp/proj", source: "vscode" } },
+    { type: "event_msg", payload: { type: "user_message", message: `work on ${id}` } },
+    { type: "event_msg", payload: { type: "agent_message", message: "done" } },
+  ].map((line) => JSON.stringify(line)).join("\n"), "utf8");
+
+  writeCodex(active, "active");
+  writeCodex(archive, "archived");
+  const agg = scanSourceSessions({
+    id: "codex",
+    label: "Codex CLI + ChatGPT app",
+    roots: [active, archive],
+    format: "codex-sessions",
+  }, 50, { includeArchived: true });
+
+  assert.equal(agg.totalSessions, 2);
+  assert.equal(agg.archivedSessions, 1);
+  assert.equal(agg.sessions.find((s) => s.sessionId === "archived")?.archived, true);
+  assert.equal(agg.sessions.find((s) => s.sessionId === "active")?.archived, undefined);
+});
+
 // ---- judge self-sessions are instrumentation, not user work ----
 
 test("parsers drop OpenEval's own judge-stub sessions", () => {

--- a/tests/collection.test.ts
+++ b/tests/collection.test.ts
@@ -262,7 +262,9 @@ test("hermes-json sessions parse into model, tools, and duration", () => {
   assert.equal(s.sessionId, "20260531_000552_3e2fd6");
   assert.equal(s.toolCalls, 1);
   assert.equal(s.durationMs, 60000);
+  assert.equal(s.numTurns, 1);
   assert.equal(s.metricSources.duration, "measured");
   assert.equal(s.metricSources.tokens, "missing"); // Hermes records no usage
+  assert.ok(s.parseWarnings.includes("turn count inferred from user messages"));
   assert.equal(s.startedAt, Date.parse("2026-05-31T00:05:53.370621"));
 });

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import type { CaseDefinition, GraderResult, RunnerResult } from "../lib/types";
 
 /**
@@ -133,6 +134,50 @@ test("executeCase: budget exceeded maps to failed even when graders pass", async
   assert.equal(rec.budget_exceeded, true);
   assert.ok(rec.error_msg?.includes("Budget exceeded"), `error_msg carries the reason: ${rec.error_msg}`);
   assert.equal(rec.evaluation?.passed, true, "graders themselves passed");
+});
+
+test("executeCase: visual input rejects a cloned symlink that escapes the workdir", async () => {
+  const outside = path.join(tmpRoot, "outside-image.png");
+  const repo = path.join(tmpRoot, "visual-symlink-repo");
+  fs.writeFileSync(outside, "private image bytes");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.symlinkSync(outside, path.join(repo, "leak.png"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+  execFileSync("git", ["add", "leak.png"], { cwd: repo });
+  execFileSync("git", ["-c", "user.email=eval@local", "-c", "user.name=eval", "commit", "-q", "-m", "fixture"], { cwd: repo });
+
+  const { executeCase } = await import("../lib/executor");
+  await ensureRun("run-exec");
+  const def = caseDef({
+    id: "exec-visual-symlink",
+    setup: { type: "git-clone", repo },
+    visual: { kind: "screenshot", requires_vision_input: true, input_images: ["leak.png"] },
+    graders: [{ type: "regex_match", pattern: "hello", source: "final_text" }],
+  });
+
+  const rec = await executeCase("run-exec", def, "headless", 33, undefined, 0, undefined);
+  assert.equal(rec.status, "error");
+  assert.match(rec.error_msg ?? "", /visual input escapes the case workdir/i);
+});
+
+test("executeCase: fixture setup refuses symlinks instead of copying host files", async () => {
+  const outside = path.join(tmpRoot, "outside-fixture-secret.txt");
+  const fixture = path.join(tmpRoot, "fixtures", "symlink-fixture");
+  fs.writeFileSync(outside, "private fixture bytes");
+  fs.mkdirSync(fixture, { recursive: true });
+  fs.symlinkSync(outside, path.join(fixture, "leak.txt"));
+
+  const { executeCase } = await import("../lib/executor");
+  await ensureRun("run-exec");
+  const def = caseDef({
+    id: "exec-fixture-symlink",
+    setup: { type: "fixture", fixture: "symlink-fixture" },
+    graders: [{ type: "file_exists", path: "leak.txt" }],
+  });
+
+  const rec = await executeCase("run-exec", def, "headless", 34, undefined, 0, undefined);
+  assert.equal(rec.status, "error");
+  assert.match(rec.error_msg ?? "", /fixture symlinks are not supported/i);
 });
 
 test("executeCase: runner failure keeps diagnostics out of finalText and lands status=error", async () => {

--- a/tests/golden-parse.test.ts
+++ b/tests/golden-parse.test.ts
@@ -102,7 +102,7 @@ test("golden: claude-projects interactive session (no result record)", () => {
   assert.equal(session.modeSummary.gitBranch, "main");
   assert.equal(session.cliVersion, "2.0.1");
   assert.ok(session.parseWarnings.includes("no final result event found"));
-  assert.ok(session.parseWarnings.includes("turn count inferred from messageCount"));
+  assert.ok(session.parseWarnings.includes("turn count inferred from user messages"));
 });
 
 test("golden: codex NEW rollout (session_meta/turn_context/event_msg/response_item)", () => {
@@ -125,7 +125,7 @@ test("golden: codex NEW rollout (session_meta/turn_context/event_msg/response_it
       turns: "inferred",
     },
     durationMs: 8000,
-    numTurns: 2, // response_item user echo + agent_message
+    numTurns: 1, // one turn_context record; response_item/event echoes are not extra turns
     // input_tokens includes the cached portion; fresh = 8000 - 2500.
     inputTokens: 5500,
     outputTokens: 650,
@@ -150,6 +150,7 @@ test("golden: codex NEW rollout (session_meta/turn_context/event_msg/response_it
   });
 
   assert.ok(session.costUsd > 0);
+  assert.ok(session.parseWarnings.includes("turn count inferred from turn context records"));
   assert.equal(session.isError, true);
   assert.equal(session.userType, "codex_cli");
   assert.equal(session.modeSummary.entrypoint, "cli");
@@ -173,7 +174,7 @@ test("golden: codex OLD rollout (response_item message records, no token_count)"
     sessionId: "golden-codex-old",
     project: "/Users/tester/projects/ledger",
     displayTitle: "Sum the totals column in data.csv",
-    lastPromptPreview: null, // only event_msg/user_msg records feed the preview
+    lastPromptPreview: "Sum the totals column in data.csv", // old Codex response_item user records are now captured too
     model: null,
     metricSources: {
       model: "missing",
@@ -183,7 +184,7 @@ test("golden: codex OLD rollout (response_item message records, no token_count)"
       turns: "inferred",
     },
     durationMs: 4000,
-    numTurns: 2,
+    numTurns: 1, // one legacy response_item user message
     inputTokens: 0,
     outputTokens: 0,
     cacheReadTokens: 0,
@@ -207,6 +208,7 @@ test("golden: codex OLD rollout (response_item message records, no token_count)"
   });
 
   assert.equal(session.costUsd, 0);
+  assert.ok(session.parseWarnings.includes("turn count inferred from user messages"));
   assert.ok(session.parseWarnings.includes("model missing from trace"));
   assert.ok(session.parseWarnings.includes("token usage missing from trace"));
   assert.ok(session.parseWarnings.includes("source: codex_cli 0.20.0"));

--- a/tests/grader.test.ts
+++ b/tests/grader.test.ts
@@ -87,6 +87,37 @@ test("file_contains matches regex and honors negate / missing / invalid", async 
   });
 });
 
+test("file graders reject traversal and symlink escapes from the workdir", async () => {
+  await withWorkdir(async (dir) => {
+    const outside = path.join(path.dirname(dir), `outside-${path.basename(dir)}.txt`);
+    await fs.writeFile(outside, "host secret marker");
+    await fs.symlink(outside, path.join(dir, "escaped.txt"));
+    try {
+      const traversal = await runGrader({ type: "file_contains", path: `../${path.basename(outside)}`, pattern: "host secret" }, ctxFor(dir));
+      assert.equal(traversal.passed, false);
+      assert.match(traversal.detail, /escapes the workdir/i);
+
+      const symlink = await runGrader({ type: "file_contains", path: "escaped.txt", pattern: "host secret" }, ctxFor(dir));
+      assert.equal(symlink.passed, false);
+      assert.match(symlink.detail, /escapes the workdir/i);
+    } finally {
+      await fs.rm(outside, { force: true });
+    }
+  });
+});
+
+test("absence-style graders cannot pass an invalid outside path", async () => {
+  await withWorkdir(async (dir) => {
+    const exists = await runGrader({ type: "file_exists", path: "../outside-missing.txt", negate: true }, ctxFor(dir));
+    assert.equal(exists.passed, false);
+    assert.match(exists.detail, /escapes the workdir/i);
+
+    const deleted = await runGrader({ type: "file_deleted", path: "../outside-missing.txt" }, ctxFor(dir));
+    assert.equal(deleted.passed, false);
+    assert.match(deleted.detail, /escapes the workdir/i);
+  });
+});
+
 // ---- file_eq ----
 
 test("file_eq compares content with and without trim", async () => {

--- a/tests/harness-metadata.test.ts
+++ b/tests/harness-metadata.test.ts
@@ -4,9 +4,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { BUILTIN_DESCRIPTORS } from "../lib/adapters/builtin";
 import { validateDescriptor } from "../lib/adapters/schema";
-import { buildDescriptorCommand, resolveDescriptorBinInfo } from "../lib/adapters/generic";
-import { discoverModels, resolveDefaultModel } from "../lib/models";
-import { runProbe } from "../lib/adapters/discover";
+import { buildDescriptorCommand, parseGenericJsonlLine, resolveDescriptorBinInfo } from "../lib/adapters/generic";
+import { discoverModels, isValidModelId, resolveDefaultModel } from "../lib/models";
+import { probeFlagObserved, runProbe } from "../lib/adapters/discover";
 
 test("Codex declares the image flag exposed by its installed CLI", () => {
   const raw = BUILTIN_DESCRIPTORS.find((descriptor) => descriptor.id === "codex");
@@ -113,4 +113,28 @@ test("harness probing verifies version and help without running a model", async 
   const help = await runProbe(process.execPath, ["--help"]);
   assert.equal(version.ok, true);
   assert.equal(help.ok, true);
+});
+
+test("harness probing matches the descriptor flag, not a hardcoded image option", () => {
+  assert.equal(probeFlagObserved("Usage: agent --attach FILE\n--other VALUE", "--attach"), true);
+  assert.equal(probeFlagObserved("Usage: agent --attach FILE", "--image"), false);
+  assert.equal(probeFlagObserved("  --attach=FILE", "--attach"), true);
+  assert.equal(probeFlagObserved("  --image FILE", "-i"), false);
+});
+
+test("generic JSONL boolean fields preserve textual false values", () => {
+  const acc: any = { startedAt: Date.now(), transcript: [], toolCalls: [], finalText: "", result: null };
+  parseGenericJsonlLine('{"name":"shell","id":"c1"}', acc, { fields: { toolCallName: "name", toolCallId: "id" } });
+  parseGenericJsonlLine('{"id":"c1","output":"ok","error":"false"}', acc, { fields: { toolCallOutput: "output", toolCallId: "id", toolCallError: "error" } });
+  parseGenericJsonlLine('{"type":"done","error":"false"}', acc, { fields: { isError: "error" } });
+  assert.equal(acc.toolCalls[0].isError, false);
+  assert.equal(acc.result.isError, false);
+  assert.equal(acc.result.exitCode, 0);
+});
+
+test("model id validation accepts custom ids but rejects blank and control-filled values", () => {
+  assert.equal(isValidModelId("provider/model-v1"), true);
+  assert.equal(isValidModelId("  provider/model-v1  "), true);
+  assert.equal(isValidModelId("   "), false);
+  assert.equal(isValidModelId("provider/model\n-v1"), false);
 });

--- a/tests/harness-metadata.test.ts
+++ b/tests/harness-metadata.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { BUILTIN_DESCRIPTORS } from "../lib/adapters/builtin";
+import { validateDescriptor } from "../lib/adapters/schema";
+import { discoverModels } from "../lib/models";
+
+test("Codex declares the image flag exposed by its installed CLI", () => {
+  const raw = BUILTIN_DESCRIPTORS.find((descriptor) => descriptor.id === "codex");
+  assert.ok(raw);
+  const { descriptor, issues } = validateDescriptor(raw, "test:codex");
+  assert.deepEqual(issues, []);
+  assert.equal(descriptor?.capabilities.supportsVisionInput, true);
+  assert.deepEqual(descriptor?.capabilities.permissionModes, ["bypassPermissions", "default"]);
+});
+
+test("Hermes descriptor matches its query, image, and non-structured output CLI", () => {
+  const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), "harnesses/hermes.harness.json"), "utf8"));
+  const { descriptor, issues } = validateDescriptor(raw, "test:hermes");
+  assert.deepEqual(issues, []);
+  assert.equal(descriptor?.parser, "text");
+  assert.deepEqual(descriptor?.argTemplate, ["chat", "--query", "{prompt}", "--quiet", "--cli"]);
+  assert.equal(descriptor?.capabilities.supportsVisionInput, true);
+  assert.deepEqual(descriptor?.capabilities.permissionModes, []);
+  assert.equal(descriptor?.capabilities.reportsCost, false);
+  assert.equal(descriptor?.capabilities.reportsTokens, false);
+  assert.equal(descriptor?.capabilities.reportsTurns, false);
+});
+
+test("an omitted vision declaration stays unknown instead of becoming a false claim", () => {
+  const { descriptor, issues } = validateDescriptor({
+    id: "unknown-vision",
+    label: "Unknown vision harness",
+    binNames: ["unknown-vision"],
+    parser: "text",
+    argTemplate: ["{prompt}"],
+  }, "test:unknown-vision");
+  assert.deepEqual(issues, []);
+  assert.equal(descriptor?.capabilities.supportsVisionInput, null);
+});
+
+test("an unknown harness does not receive another harness's model catalog", () => {
+  assert.deepEqual(discoverModels("does-not-exist"), []);
+});
+
+test("Claude model aliases inherit the harness's proven image-input capability", () => {
+  const models = discoverModels("claude-code");
+  assert.equal(models.find((model) => model.id === "opus")?.capabilities.visionInput, true);
+  assert.equal(models.find((model) => model.id === "sonnet")?.capabilities.visionInput, true);
+});

--- a/tests/harness-metadata.test.ts
+++ b/tests/harness-metadata.test.ts
@@ -4,7 +4,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { BUILTIN_DESCRIPTORS } from "../lib/adapters/builtin";
 import { validateDescriptor } from "../lib/adapters/schema";
-import { discoverModels } from "../lib/models";
+import { buildDescriptorCommand, resolveDescriptorBinInfo } from "../lib/adapters/generic";
+import { discoverModels, resolveDefaultModel } from "../lib/models";
+import { runProbe } from "../lib/adapters/discover";
 
 test("Codex declares the image flag exposed by its installed CLI", () => {
   const raw = BUILTIN_DESCRIPTORS.find((descriptor) => descriptor.id === "codex");
@@ -12,6 +14,8 @@ test("Codex declares the image flag exposed by its installed CLI", () => {
   const { descriptor, issues } = validateDescriptor(raw, "test:codex");
   assert.deepEqual(issues, []);
   assert.equal(descriptor?.capabilities.supportsVisionInput, true);
+  assert.deepEqual(descriptor?.helpArgs, ["exec", "--help"]);
+  assert.equal(descriptor?.imageFlag, "-i");
   assert.deepEqual(descriptor?.capabilities.permissionModes, ["bypassPermissions", "default"]);
 });
 
@@ -20,12 +24,16 @@ test("Hermes descriptor matches its query, image, and non-structured output CLI"
   const { descriptor, issues } = validateDescriptor(raw, "test:hermes");
   assert.deepEqual(issues, []);
   assert.equal(descriptor?.parser, "text");
+  assert.deepEqual(descriptor?.helpArgs, ["chat", "--help"]);
   assert.deepEqual(descriptor?.argTemplate, ["chat", "--query", "{prompt}", "--quiet", "--cli"]);
   assert.equal(descriptor?.capabilities.supportsVisionInput, true);
   assert.deepEqual(descriptor?.capabilities.permissionModes, []);
   assert.equal(descriptor?.capabilities.reportsCost, false);
   assert.equal(descriptor?.capabilities.reportsTokens, false);
   assert.equal(descriptor?.capabilities.reportsTurns, false);
+  assert.equal(descriptor?.imageFlag, "--image");
+  assert.equal(descriptor?.liveTrace?.format, "hermes-json");
+  assert.deepEqual(descriptor?.liveTrace?.roots, ["~/.hermes/sessions"]);
 });
 
 test("an omitted vision declaration stays unknown instead of becoming a false claim", () => {
@@ -48,4 +56,61 @@ test("Claude model aliases inherit the harness's proven image-input capability",
   const models = discoverModels("claude-code");
   assert.equal(models.find((model) => model.id === "opus")?.capabilities.visionInput, true);
   assert.equal(models.find((model) => model.id === "sonnet")?.capabilities.visionInput, true);
+});
+
+test("unknown configured models do not claim visual-code output", () => {
+  const models = discoverModels("ncode");
+  assert.equal(models.find((model) => model.id === "opus")?.capabilities.visualCodeOutput, null);
+});
+
+test("descriptor defaults resolve consistently for runs and model APIs", () => {
+  assert.deepEqual(resolveDefaultModel("ncode"), { id: "glm-5.2", source: "descriptor" });
+});
+
+test("binary resolution honors the execution environment override", () => {
+  const envKey = `OPENEVAL_TEST_BIN_${process.pid}`;
+  const { descriptor, issues } = validateDescriptor({
+    id: "env-bin-test",
+    label: "Environment binary test",
+    binNames: ["definitely-not-on-path"],
+    defaultBin: "definitely-not-on-path",
+    binEnvVar: envKey,
+    parser: "text",
+    argTemplate: ["{prompt}"],
+  }, "test:env-bin");
+  assert.deepEqual(issues, []);
+  const before = process.env[envKey];
+  process.env[envKey] = process.execPath;
+  try {
+    assert.deepEqual(resolveDescriptorBinInfo(descriptor!), { bin: process.execPath, source: "env" });
+  } finally {
+    if (before == null) delete process.env[envKey]; else process.env[envKey] = before;
+  }
+});
+
+test("image attachments become repeated descriptor flag pairs", () => {
+  const raw = BUILTIN_DESCRIPTORS.find((descriptor) => descriptor.id === "codex")!;
+  const { descriptor } = validateDescriptor(raw, "test:codex-image-command");
+  const command = buildDescriptorCommand(descriptor!, {
+    caseId: "image-case",
+    workdir: "/tmp/workdir",
+    prompt: "inspect the image",
+    maxTurns: 5,
+    timeoutMs: 1000,
+    permissionMode: "default",
+    model: "gpt-5.5",
+    extraArgs: [],
+    images: ["/tmp/workdir/a.png", "/tmp/workdir/b.png"],
+  });
+  assert.deepEqual(command.args, [
+    "exec", "--json", "--skip-git-repo-check", "-s", "read-only", "-m", "gpt-5.5",
+    "-i", "/tmp/workdir/a.png", "-i", "/tmp/workdir/b.png", "inspect the image",
+  ]);
+});
+
+test("harness probing verifies version and help without running a model", async () => {
+  const version = await runProbe(process.execPath, ["--version"]);
+  const help = await runProbe(process.execPath, ["--help"]);
+  assert.equal(version.ok, true);
+  assert.equal(help.ok, true);
 });

--- a/tests/insights-judge.test.ts
+++ b/tests/insights-judge.test.ts
@@ -37,6 +37,12 @@ function writeTmp(lines: unknown[]): string {
   return file;
 }
 
+function writeTmpJson(value: unknown): string {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "judge-test-")), "t.json");
+  fs.writeFileSync(file, JSON.stringify(value, null, 2));
+  return file;
+}
+
 test("extractJudgeDigest pulls the conversational spine from a Claude-shaped transcript", () => {
   const file = writeTmp([
     { type: "user", message: { role: "user", content: "Fix the login bug please" } },
@@ -60,6 +66,30 @@ test("extractJudgeDigest understands Codex event_msg payloads", () => {
   const d = extractJudgeDigest(file);
   assert.equal(d.firstUser, "add a retry to the fetch");
   assert.equal(d.lastAssistant, "Added exponential backoff.");
+});
+
+test("extractJudgeDigest understands legacy Codex response_item messages", () => {
+  const file = writeTmp([
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "repair the ledger totals" }] } },
+    { type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "The ledger now balances." }] } },
+  ]);
+  const d = extractJudgeDigest(file);
+  assert.equal(d.firstUser, "repair the ledger totals");
+  assert.equal(d.lastAssistant, "The ledger now balances.");
+});
+
+test("extractJudgeDigest understands Hermes single-JSON conversations", () => {
+  const file = writeTmpJson({
+    session_id: "hermes-judge",
+    messages: [
+      { role: "user", content: "trace the missing invoice" },
+      { role: "assistant", content: "The invoice was restored." },
+      { role: "tool", content: "internal tool noise" },
+    ],
+  });
+  const d = extractJudgeDigest(file);
+  assert.equal(d.firstUser, "trace the missing invoice");
+  assert.equal(d.lastAssistant, "The invoice was restored.");
 });
 
 test("buildJudgePrompt embeds the digest and demands bare JSON", () => {

--- a/tests/live-cache.test.ts
+++ b/tests/live-cache.test.ts
@@ -108,6 +108,20 @@ test("live-cache: ftsUpsert deletes by remembered rowid and still replaces legac
   });
 });
 
+test("live-cache: FTS freshness ignores rows from an older extraction contract", () => {
+  withMemoryDb(() => {
+    const conn = new Database(":memory:");
+    _setCacheDbForTest(conn);
+    conn
+      .prepare("INSERT INTO session_fts (user_text, assistant_text, title, project, source_id, file, at) VALUES (?, ?, ?, ?, ?, ?, ?)")
+      .run("stale text", "", "t", "/p", "src", "/stale.jsonl", 1);
+    conn.prepare("INSERT INTO fts_meta (file, mtime_ms, size, indexed_at) VALUES (?, ?, ?, ?)").run("/stale.jsonl", 10, 20, 1);
+
+    assert.equal(ftsIndexedFiles().has("/stale.jsonl"), false);
+    conn.close();
+  });
+});
+
 test("live-cache: FTS index round-trips, replaces on re-index, and survives odd queries", () => {
   withMemoryDb(() => {
     ftsUpsert(

--- a/tests/live.test.ts
+++ b/tests/live.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   compactDisplayPath,
+  parseSessionTranscript,
   isPathInLiveSource,
   redactSensitiveText,
   scanLiveSessions,
@@ -28,6 +29,33 @@ function writeSession(lines: unknown[], extras: string[] = []): string {
   );
   return file;
 }
+
+test("parseSessionTranscript opens Hermes single-JSON sessions", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-hermes-transcript-"));
+  const file = path.join(dir, "session_20260715_000000_demo.json");
+  fs.writeFileSync(file, JSON.stringify({
+    session_id: "hermes-transcript",
+    model: "gpt-5.5",
+    session_start: "2026-07-15T00:00:00.000Z",
+    last_updated: "2026-07-15T00:00:03.000Z",
+    messages: [
+      { role: "user", content: "inspect the image" },
+      { role: "assistant", content: "I will inspect it.", tool_calls: [{ id: "tool-1", function: { name: "bash", arguments: "{\"cmd\":\"file image.png\"}" } }] },
+      { role: "tool", tool_call_id: "tool-1", content: "image.png: PNG image data", is_error: true },
+      { role: "assistant", content: "The tool reported an error." },
+    ],
+  }, null, 2));
+  try {
+    const parsed = parseSessionTranscript(file, "hermes-json");
+    assert.equal(parsed.error, undefined);
+    assert.ok(parsed.turns.some((turn) => turn.label === "You"));
+    assert.ok(parsed.turns.some((turn) => turn.label === "Tool: bash"));
+    assert.ok(parsed.turns.some((turn) => turn.label === "Tool result — error"));
+    assert.equal(parsed.turns.some((turn) => turn.type === "malformed"), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("summarizeLiveSessionFile parses observed ncode sessions without result events", () => {
   const file = writeSession([

--- a/tests/live.test.ts
+++ b/tests/live.test.ts
@@ -554,8 +554,9 @@ test("codex titles and prompt previews skip injected persona preambles", () => {
   const session = summarizeCodexSessionFile(file, "2026/06/29", Date.parse("2026-06-29T00:00:00.000Z"));
   assert.ok(session);
   assert.equal(session.displayTitle, "Fix the flaky dropdown test");
-  // the only user_msg event was the preamble — better no preview than a leaky one
-  assert.equal(session.lastPromptPreview, null);
+  // The real response_item user record is now used when the legacy user_msg
+  // stream contains only the injected preamble.
+  assert.equal(session.lastPromptPreview, "Fix the flaky dropdown test");
 });
 
 test("coordinator-root preambles are suppressed without a subagent flag", () => {


### PR DESCRIPTION
## What changed

- makes Codex/ChatGPT archive collection, harness/model capability metadata, Hermes/Codex turn counts, and prompt previews truthful
- fixes live drawer object rendering and descriptor-specific image probing
- normalizes Claude, legacy/current Codex, and Hermes conversation text for search and outcome judging, with versioned FTS reindexing
- closes symlink and traversal escapes in artifact serving, visual inputs, fixture copies, and file graders

## Root causes

- several consumers handled only one generation of each transcript protocol
- path checks were lexical and did not validate canonical symlink targets
- search-cache freshness had no extraction-contract version
- object-shaped harness metadata could reach JSX unchanged

## Validation

- `npx tsc --noEmit`
- `npm test` — 243/243 passing
- `npm run lint`
- `npm run build`
- live API smoke: four harnesses available, no descriptor issues, Collection and Timeline returned 200, and real Codex/Hermes transcript extraction and search were exercised
