### PR TITLE
optimize: measurement harness + dev-loop/token/agent fixes (test output -99.5%, live-parse benchmark)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ data/
 # Throwaway data root used by `npm test` (OPENEVAL_DATA_ROOT=.test-data).
 .test-data/
 
+# Raw /optimize measurement artifacts embed absolute machine paths and
+# transcript-derived data (public-upload-audit rejects them). The numbers that
+# matter are copied into .optimize/ledger.md + baseline.json, which stay tracked.
+.optimize/runs/
+
 # HyperFrames preview/render/cache output.
 media/**/.hyperframes/
 media/**/.thumbnails/

--- a/.ignore
+++ b/.ignore
@@ -2,3 +2,6 @@
 # Lockfile matches drown out source hits in repo-wide searches; read it
 # directly (Read / jq / python) when you actually need dependency metadata.
 package-lock.json
+# Per-run measurement artifacts — numbers live in ledger.md/baseline.json;
+# raw run JSONs only add noise to repo-wide searches.
+.optimize/runs/

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+# ripgrep/search-tool exclusions (not .gitignore — these files stay committed).
+# Lockfile matches drown out source hits in repo-wide searches; read it
+# directly (Read / jq / python) when you actually need dependency metadata.
+package-lock.json

--- a/.optimize/backlog.md
+++ b/.optimize/backlog.md
@@ -1,0 +1,4 @@
+# Backlog
+
+| # | area | fix | evidence | impact | confidence | effort | score |
+|---|------|-----|----------|--------|------------|--------|-------|

--- a/.optimize/backlog.md
+++ b/.optimize/backlog.md
@@ -2,3 +2,8 @@
 
 | # | area | fix | evidence | impact | confidence | effort | score |
 |---|------|-----|----------|--------|------------|--------|-------|
+| 1 | runtime | create minimal benchmark for lib/live.ts session scan (cold vs warm cache) — no runtime harness exists | openeval-dev-loop skill: cold scan ~25s incl. 567MB codex file; no bench probe today | high (unlocks all runtime runs) | 0.9 | 1h | high |
+| 2 | devloop | test suite child-process overhead: 28 files × tsx import under node --test; try shared compile cache or fewer processes | probe: test 9.7s median for ~110 fast tests | ~5s/run × many runs/wk | 0.6 | 1h | mid |
+| 3 | devloop | measure warm `next build` (43.9s was cold, fresh worktree); only then consider build fixes | run 1 baseline, runs=1 cold | unknown until measured | 0.9 | 10m | mid |
+| 4 | tokens | add .optimize/runs/ to .ignore — measurement artifacts self-inflate repo_tokens (+12.4k in one run) | verify-tokens delta 385.5k → 397.9k | ~1k/errant grep | 0.8 | 2m | low |
+| 5 | health | eslint 8.57.1 EOL warning on install; eslint 9 migration is a major bump — out of scope for /optimize, flag to owner | npm ci deprecation warnings | n/a | 0.9 | — | note |

--- a/.optimize/backlog.md
+++ b/.optimize/backlog.md
@@ -2,8 +2,10 @@
 
 | # | area | fix | evidence | impact | confidence | effort | score |
 |---|------|-----|----------|--------|------------|--------|-------|
-| 1 | runtime | create minimal benchmark for lib/live.ts session scan (cold vs warm cache) — no runtime harness exists | openeval-dev-loop skill: cold scan ~25s incl. 567MB codex file; no bench probe today | high (unlocks all runtime runs) | 0.9 | 1h | high |
-| 2 | devloop | test suite child-process overhead: 28 files × tsx import under node --test; try shared compile cache or fewer processes | probe: test 9.7s median for ~110 fast tests | ~5s/run × many runs/wk | 0.6 | 1h | mid |
-| 3 | devloop | measure warm `next build` (43.9s was cold, fresh worktree); only then consider build fixes | run 1 baseline, runs=1 cold | unknown until measured | 0.9 | 10m | mid |
-| 4 | tokens | add .optimize/runs/ to .ignore — measurement artifacts self-inflate repo_tokens (+12.4k in one run) | verify-tokens delta 385.5k → 397.9k | ~1k/errant grep | 0.8 | 2m | low |
-| 5 | health | eslint 8.57.1 EOL warning on install; eslint 9 migration is a major bump — out of scope for /optimize, flag to owner | npm ci deprecation warnings | n/a | 0.9 | — | note |
+| 1 | runtime | profile parseLiveSession and close the 30% throughput gap vs codex parser (71.8 vs 105.0 MB/s, run-2 bench) | .optimize/runs/20260718T-run2-bench.json | scan-time on every /live and /collection load | 0.6 | 2h | high |
+| 2 | devloop | test suite child-process overhead: 28 files × tsx import under node --test; try shared compile cache or fewer processes | probe: test 9.7–12.7s median for ~110 fast tests | ~5s/run × many runs/wk | 0.6 | 1h | mid |
+| 3 | devloop | measure warm `next build` on an idle machine (43.9s cold run 1; 52.5s run 2 was load-poisoned) | run-2 noise flag in ledger | unknown until measured | 0.9 | 10m | mid |
+| 4 | health | eslint 8.57.1 EOL warning on install; eslint 9 migration is a major bump — out of scope for /optimize, flag to owner | npm ci deprecation warnings | n/a | 0.9 | — | note |
+| 5 | agent | measurement discipline: probe sweeps race other agent sessions on this box (load avg 18–21 seen); consider a load-avg guard note in probes.sh header or an idle check before sweeps | run-2 lint 7.7/15.0/2.3s spread | protects every future number | 0.8 | 15m | mid |
+
+Done (for grep): run-1 #1 bench harness → 6c8be58; run-1 #4 .optimize/runs .ignore → 86c6e9d.

--- a/.optimize/baseline.json
+++ b/.optimize/baseline.json
@@ -24,6 +24,38 @@
         "lint": true,
         "build": true
       }
+    },
+    {
+      "ts": "2026-07-18T21:50:44+00:00",
+      "git": {
+        "rev": "66a5557",
+        "dirty": true
+      },
+      "medians": {
+        "types": 9.262
+      },
+      "output_tokens": {
+        "types": 0
+      },
+      "ok": {
+        "types": true
+      }
+    },
+    {
+      "ts": "2026-07-18T21:52:28+00:00",
+      "git": {
+        "rev": "66a5557",
+        "dirty": true
+      },
+      "medians": {
+        "test": 10.795
+      },
+      "output_tokens": {
+        "test": 75
+      },
+      "ok": {
+        "test": true
+      }
     }
   ]
 }

--- a/.optimize/baseline.json
+++ b/.optimize/baseline.json
@@ -56,6 +56,63 @@
       "ok": {
         "test": true
       }
+    },
+    {
+      "ts": "2026-07-19T01:29:14+00:00",
+      "git": {
+        "rev": "b29139e",
+        "dirty": false
+      },
+      "medians": {
+        "types": 5.321,
+        "test": 12.749,
+        "lint": 15.048,
+        "build": 52.502
+      },
+      "output_tokens": {
+        "types": 0,
+        "test": 75,
+        "lint": 67,
+        "build": 801
+      },
+      "ok": {
+        "types": true,
+        "test": true,
+        "lint": true,
+        "build": true
+      }
+    },
+    {
+      "ts": "2026-07-19T01:31:52+00:00",
+      "git": {
+        "rev": "b29139e",
+        "dirty": true
+      },
+      "medians": {
+        "lint": 2.275
+      },
+      "output_tokens": {
+        "lint": 67
+      },
+      "ok": {
+        "lint": true
+      }
+    },
+    {
+      "ts": "2026-07-19T01:32:36+00:00",
+      "git": {
+        "rev": "b29139e",
+        "dirty": true
+      },
+      "medians": {
+        "bench": 2.91
+      },
+      "output_tokens": {
+        "bench": 28
+      },
+      "ok": {
+        "bench": true
+      }
     }
   ]
 }

--- a/.optimize/baseline.json
+++ b/.optimize/baseline.json
@@ -1,0 +1,29 @@
+{
+  "runs": [
+    {
+      "ts": "2026-07-18T21:47:40+00:00",
+      "git": {
+        "rev": "ca1383b",
+        "dirty": true
+      },
+      "medians": {
+        "types": 19.707,
+        "test": 9.675,
+        "lint": 7.744,
+        "build": 43.935
+      },
+      "output_tokens": {
+        "types": 0,
+        "test": 13996,
+        "lint": 67,
+        "build": 801
+      },
+      "ok": {
+        "types": true,
+        "test": true,
+        "lint": true,
+        "build": true
+      }
+    }
+  ]
+}

--- a/.optimize/ledger.md
+++ b/.optimize/ledger.md
@@ -3,6 +3,10 @@
 Conventions: exchange rate 10k wasted tokens ≈ 60s. Estimator recorded per run.
 Probes: see probes.sh. Never run the `build` probe while a dev server serves the
 same checkout (openeval-dev-loop skill).
+runs/ is LOCAL-ONLY (gitignored): raw measure/tokens JSONs embed absolute
+machine paths and transcript excerpts, which scripts/public-upload-audit.sh
+rejects for this public repo. Copy any number worth keeping into this ledger;
+cross-machine comparisons were already invalid (hard rule: same machine only).
 
 ## Run 1 — 2026-07-18 (full, ca1383b, clean tree, estimator heuristic-chars/4, 10k tok ≈ 60s)
 Baseline (fresh worktree, cold caches): types 19.7s (warm re-run: 9.3s), test 9.7s,

--- a/.optimize/ledger.md
+++ b/.optimize/ledger.md
@@ -1,0 +1,5 @@
+# OpenEval optimization ledger
+
+Conventions: exchange rate 10k wasted tokens ≈ 60s. Estimator recorded per run.
+Probes: see probes.sh. Never run the `build` probe while a dev server serves the
+same checkout (openeval-dev-loop skill).

--- a/.optimize/ledger.md
+++ b/.optimize/ledger.md
@@ -15,3 +15,16 @@ refetch waste 104.9k over 10 sessions (snapshot of primary + 2 worktree slugs).
 - Tokens caveat: repo_tokens rose 385.5k → 397.9k during the run — self-inflation from .optimize/runs/*.json artifacts, not a regression.
 - Backlog: top 3 below.
 - Next run: worktree bootstrap costs ~45s npm ci + cold caches — expect types ~9.3s warm, not 19.7s. Start at backlog #1 (runtime benchmark harness for lib/live.ts scan). Probes are trusted. Session-token comparisons must reuse the same 10-transcript snapshot set or skip the claim.
+
+## Run 2 — 2026-07-18 (full, b29139e, clean tree, estimator heuristic-chars/4, 10k tok ≈ 60s)
+MEASUREMENT NOISE FLAG: machine load avg 18–21 (other agent sessions). The same
+lint command measured 7.7s (run 1) / 15.0s (run 2 sweep) / 2.3s (idle recheck,
+eslint cache warm) with zero relevant code change. Cross-run wall-times on this
+box are unreliable; only back-to-back A/B pairs within one run count as evidence.
+- Probes (warm caches): types 5.3s (cold 19.7s run 1, −73% — incremental working), test 12.7s @ 75 tok output, lint noisy (see flag), build 52.5s under load (cold 43.9s — backlog #3 stays open, number is load-poisoned).
+- Applied: optimize: runtime benchmark for live-session parsing (6c8be58) | new `npm run bench:live` + `bench` probe. Baseline: claude-projects 71.8MB/s cold, codex-sessions 105.0MB/s cold, warm cache hit <1ms; probe median 2.91s, 28 tok output. Deterministic 32MB corpora from golden fixtures; in-memory cache DB; never reads real session dirs. Closes run-1 backlog #1.
+- Applied: optimize: .ignore .optimize/runs/ (86c6e9d) | rg file set for .optimize: 4 files (ledger/backlog/baseline/probes), runs/*.json out. Closes run-1 backlog #4.
+- Verified green after fixes: tsc, lint (0 warnings), test ×3 (run-2 sweep), bench ×4.
+- Tokens: probe outputs now test 75 / lint 67 / build 801 / bench 28 — no loud probes left. Session mining skipped (no session-area fix this run; run-1 snapshot remains the reference set).
+- Backlog: top 3 below.
+- Next run: bench probe is the harness — attempt one parser optimization. Lead: claude-projects parses 30% slower than codex (71.8 vs 105.0MB/s) on same-size corpora; profile parseLiveSession before touching anything, and verify with back-to-back bench medians in the same process batch (machine-load flag above).

--- a/.optimize/ledger.md
+++ b/.optimize/ledger.md
@@ -3,3 +3,15 @@
 Conventions: exchange rate 10k wasted tokens ≈ 60s. Estimator recorded per run.
 Probes: see probes.sh. Never run the `build` probe while a dev server serves the
 same checkout (openeval-dev-loop skill).
+
+## Run 1 — 2026-07-18 (full, ca1383b, clean tree, estimator heuristic-chars/4, 10k tok ≈ 60s)
+Baseline (fresh worktree, cold caches): types 19.7s (warm re-run: 9.3s), test 9.7s,
+lint 7.7s, build 43.9s. Tokens: surfaces 1.5k, repo 385.5k, probes 14.9k,
+refetch waste 104.9k over 10 sessions (snapshot of primary + 2 worktree slugs).
+- Applied: optimize: terse node:test reporter (04ae8eb) | npm test output 13,996 → 75 tokens (−99.5%); time 9.68s → 10.79s median, inside baseline sample spread 9.3–12.1s; failure details verified intact via forced failure. Information removed: per-test "ok" TAP lines on green runs — none.
+- Applied: optimize: .ignore for package-lock.json (502abb9) | rg file set 290 → 289 (lockfile out); representative repo-wide grep ("next") −2.8KB (−17%). NOTE: tokens.py `unignored_noise` tracks gitignore only, so its 67k figure will NOT move — do not re-attempt this fix based on that number.
+- Applied: optimize: CLAUDE.md symlink → NCODE.md (23d49c0) | 6/10 recent sessions manually located NCODE.md (~1.7k tok/read + discovery); now auto-loaded. All NCODE.md commands executed green this run.
+- Not fixable here: refetch waste is 90% byte-identical preview_screenshot retakes (browser-pane stale-frame quirk, already documented in user gotchas) — no repo-side fix.
+- Tokens caveat: repo_tokens rose 385.5k → 397.9k during the run — self-inflation from .optimize/runs/*.json artifacts, not a regression.
+- Backlog: top 3 below.
+- Next run: worktree bootstrap costs ~45s npm ci + cold caches — expect types ~9.3s warm, not 19.7s. Start at backlog #1 (runtime benchmark harness for lib/live.ts scan). Probes are trusted. Session-token comparisons must reuse the same 10-transcript snapshot set or skip the claim.

--- a/.optimize/probes.sh
+++ b/.optimize/probes.sh
@@ -1,0 +1,9 @@
+# OpenEval probe suite — label | runs | command
+# Dev loop per .claude/skills/openeval-dev-loop: tsc + node:test via tsx + next lint.
+# `build` is runs=1 and MUST NOT run while a dev server serves THIS checkout
+# (next build clobbers .next and the dev server 500s until restart).
+# Tests use OPENEVAL_DATA_ROOT=.test-data (set inside the npm script) — isolated from data/.
+types | 1 | npx tsc --noEmit
+test  | 3 | npm test --silent
+lint  | 1 | npm run lint --silent
+build | 1 | npm run build --silent

--- a/.optimize/probes.sh
+++ b/.optimize/probes.sh
@@ -7,3 +7,4 @@ types | 1 | npx tsc --noEmit
 test  | 3 | npm test --silent
 lint  | 1 | npm run lint --silent
 build | 1 | npm run build --silent
+bench | 3 | npm run bench:live --silent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+NCODE.md

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "next start",
     "lint": "next lint --max-warnings=0",
     "typecheck": "tsc --noEmit",
-    "test": "OPENEVAL_DATA_ROOT=.test-data node --import tsx --test tests/*.test.ts",
+    "test": "OPENEVAL_DATA_ROOT=.test-data node --import tsx --test --test-reporter=dot tests/*.test.ts",
     "test:live": "OPENEVAL_DATA_ROOT=.test-data node --import tsx --test tests/live.test.ts",
     "test:telemetry": "OPENEVAL_DATA_ROOT=.test-data node --import tsx --test tests/telemetry.test.ts",
     "pricing:check": "tsx scripts/check-pricing-catalog.ts",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:live": "OPENEVAL_DATA_ROOT=.test-data node --import tsx --test tests/live.test.ts",
     "test:telemetry": "OPENEVAL_DATA_ROOT=.test-data node --import tsx --test tests/telemetry.test.ts",
     "pricing:check": "tsx scripts/check-pricing-catalog.ts",
+    "bench:live": "tsx scripts/bench-live.ts",
     "run:eval": "tsx lib/cli/run.ts",
     "run:case": "tsx lib/cli/run.ts --case",
     "run:headless": "tsx lib/cli/run.ts --runner headless",

--- a/scripts/bench-live.ts
+++ b/scripts/bench-live.ts
@@ -1,0 +1,79 @@
+/**
+ * Minimal deterministic benchmark for the hottest path: live-session parsing
+ * (lib/live.ts summarize*SessionFile). Real scans chew through hundreds of MB
+ * of JSONL; this generates a fixed synthetic corpus from the golden fixtures
+ * (never reads real session dirs, never touches data/live-cache.db) and times
+ * cold parses (both cache tiers miss) and warm hits (in-process Map).
+ *
+ * Output is one line per measurement — stable keys, medians of 3 — so probe
+ * runs can diff it. Corpus lives under OPENEVAL_DATA_ROOT (default .test-data),
+ * regenerated only when missing or wrong size.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { summarizeCodexSessionFile, summarizeLiveSessionFile } from "../lib/live";
+import { _setCacheDbForTest } from "../lib/live-cache";
+
+const TARGET_BYTES = 32 * 1024 * 1024;
+const FIXTURES = path.join(process.cwd(), "tests", "fixtures");
+const BENCH_DIR = path.join(process.cwd(), process.env.OPENEVAL_DATA_ROOT ?? ".test-data", "bench");
+
+const conn = new Database(":memory:");
+_setCacheDbForTest(conn);
+
+function buildCorpus(fixture: string, out: string): void {
+  const lines = fs.readFileSync(path.join(FIXTURES, fixture), "utf8").split("\n").filter(Boolean);
+  const block = lines.join("\n") + "\n";
+  const reps = Math.ceil(TARGET_BYTES / Buffer.byteLength(block));
+  fs.writeFileSync(out, block.repeat(reps));
+}
+
+function ensureCorpus(fixture: string, name: string): { paths: string[]; bytes: number } {
+  fs.mkdirSync(BENCH_DIR, { recursive: true });
+  const main = path.join(BENCH_DIR, `${name}.jsonl`);
+  if (!fs.existsSync(main) || fs.statSync(main).size < TARGET_BYTES) buildCorpus(fixture, main);
+  const paths = [main];
+  // Cold parses need distinct paths (both cache tiers key on the path);
+  // symlinks reuse the corpus bytes instead of copying 32MB per sample.
+  for (let i = 1; i < 3; i++) {
+    const link = path.join(BENCH_DIR, `${name}-cold${i}.jsonl`);
+    if (!fs.existsSync(link)) fs.symlinkSync(main, link);
+    paths.push(link);
+  }
+  return { paths, bytes: fs.statSync(main).size };
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+}
+
+function bench(name: string, fixture: string, summarize: (file: string, projectDir: string, mtime: number) => unknown): void {
+  const { paths, bytes } = ensureCorpus(fixture, name);
+  const mtime = Date.parse("2026-01-05T10:10:30.000Z");
+  const cold: number[] = [];
+  for (const p of paths) {
+    const t0 = performance.now();
+    const session = summarize(p, "-bench-project", mtime);
+    cold.push(performance.now() - t0);
+    if (!session) throw new Error(`${name}: parser returned null — bench corpus no longer parses`);
+  }
+  const warm: number[] = [];
+  for (let i = 0; i < 3; i++) {
+    const t0 = performance.now();
+    summarize(paths[0], "-bench-project", mtime);
+    warm.push(performance.now() - t0);
+  }
+  const coldMs = median(cold);
+  const mbps = bytes / (1024 * 1024) / (coldMs / 1000);
+  console.log(`${name} cold ${coldMs.toFixed(0)}ms ${mbps.toFixed(1)}MB/s (${(bytes / (1024 * 1024)).toFixed(0)}MB) | warm ${median(warm).toFixed(1)}ms`);
+}
+
+function main(): void {
+  bench("claude-projects", "claude-interactive.jsonl", summarizeLiveSessionFile);
+  bench("codex-sessions", "codex-rollout-new.jsonl", summarizeCodexSessionFile);
+  _setCacheDbForTest(null);
+  conn.close();
+}
+main();


### PR DESCRIPTION
## Summary

- Two `/optimize` runs: measurement harness (`.optimize/` ledger + probes) plus five behavior-preserving fixes, each with before/after numbers.
- `npm test` output on green runs: 13,996 → 75 tokens (−99.5%) via `--test-reporter=dot`; failure detail verified intact with a forced failure.
- New `npm run bench:live` runtime benchmark for live-session parsing (deterministic 32MB corpora generated from the golden fixtures into `.test-data/bench`, in-memory cache DB — never reads real session dirs or `data/live-cache.db`). Baseline: claude-projects 71.8MB/s, codex-sessions 105.0MB/s cold, warm cache hit <1ms.
- `.ignore` (search-tool-only excludes, files stay committed): `package-lock.json` and `.optimize/runs/` no longer drown repo-wide greps.
- `CLAUDE.md` symlink → `NCODE.md` so Claude Code auto-loads the repo guidance (6 of 10 recent sessions were manually hunting for it).
- Raw measurement JSONs (`.optimize/runs/`) are gitignored: they embed absolute machine paths and transcript excerpts, which `public-upload-audit.sh` rejects. Durable numbers live in `.optimize/ledger.md` + `baseline.json`.

Reviewer notes: the dot reporter changes `npm test`'s interactive output shape (dots instead of per-test TAP lines); scoped npm scripts (`test:live` etc.) are untouched. The ledger flags run-2 wall-times as load-poisoned (machine load avg 18–21 during the sweep) — only back-to-back A/B numbers were used to accept fixes.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint -- --max-warnings=0`
- [x] `npm run test:live` (33 pass / 0 fail; full suite also green 3×)
- [x] `bash scripts/public-upload-audit.sh`

## Notes

- [x] I did not include local run data, transcripts, workdirs, `.codex/`, `.ncode/`, `state.yaml`, or SQLite files.
- [x] Missing telemetry is still shown as missing rather than as a real zero.
- [x] New or changed cases include appropriate deterministic proof, known-bad coverage, or a clear reason why manual/LLM judgment is required. (No cases changed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
