### PR TITLE
ux: route-level loading skeletons + collection error boundaries

### DIFF
--- a/app/accuracy/loading.tsx
+++ b/app/accuracy/loading.tsx
@@ -1,0 +1,43 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="p-8 max-w-7xl mx-auto" aria-busy="true" aria-label="Loading accuracy audit">
+      <header className="mb-6">
+        <Bar className="mb-2 h-8 w-56" />
+        <Bar className="h-4 w-[26rem] max-w-full" />
+      </header>
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="card p-4 space-y-2">
+            <Bar className="h-3 w-24" />
+            <Bar className="h-7 w-14" />
+            <Bar className="h-3 w-20" />
+          </div>
+        ))}
+      </section>
+      <section className="card p-3 mb-6 flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Bar key={i} className="h-7 w-20 rounded-md" />
+          ))}
+        </div>
+        <Bar className="h-8 w-full sm:w-56 rounded-md" />
+      </section>
+      <div className="overflow-hidden rounded-lg border border-bd bg-bg-subtle">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 border-b border-bd-subtle p-4 last:border-b-0">
+            <Bar className="h-4 w-4" />
+            <div className="flex-1 space-y-2">
+              <Bar className="h-4 w-1/4" />
+              <Bar className="h-3 w-1/2" />
+            </div>
+            <Bar className="h-4 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/cases/loading.tsx
+++ b/app/cases/loading.tsx
@@ -1,0 +1,35 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="p-8 max-w-7xl mx-auto" aria-busy="true" aria-label="Loading cases">
+      <header className="mb-6">
+        <Bar className="mb-2 h-8 w-32" />
+        <Bar className="h-4 w-72" />
+      </header>
+      <div className="flex flex-wrap gap-2 mb-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Bar key={i} className="h-7 w-24 rounded-md" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div key={i} className="card p-4 space-y-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <Bar className="h-4 w-2/3" />
+              <Bar className="h-5 w-16 rounded-full" />
+            </div>
+            <Bar className="h-3 w-full" />
+            <Bar className="h-3 w-3/4" />
+            <div className="flex gap-1.5 pt-1">
+              <Bar className="h-4 w-12 rounded" />
+              <Bar className="h-4 w-14 rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/collection/error.tsx
+++ b/app/collection/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+import RouteError from "@/components/ErrorBoundaryClient";
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <RouteError error={error} reset={reset} title="Collection failed to load" />;
+}

--- a/app/collection/loading.tsx
+++ b/app/collection/loading.tsx
@@ -1,0 +1,56 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="p-4 md:p-6 max-w-6xl mx-auto" aria-busy="true" aria-label="Loading collection">
+      <header className="mb-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Bar className="mb-2 h-8 w-48" />
+            <Bar className="h-4 w-[28rem] max-w-full" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Bar className="h-8 w-24 rounded-md" />
+            <Bar className="h-8 w-36 rounded-md" />
+            <Bar className="h-8 w-24 rounded-md" />
+          </div>
+        </div>
+      </header>
+
+      <div className="mb-6 flex items-center gap-2 overflow-hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Bar key={i} className="h-7 w-24 rounded-md" />
+        ))}
+      </div>
+
+      <section className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-bd-subtle bg-bg-subtle/30 p-3 space-y-2">
+            <Bar className="h-3 w-24" />
+            {Array.from({ length: 3 }).map((_, j) => (
+              <div key={j} className="flex items-center justify-between gap-2">
+                <Bar className="h-3 w-24" />
+                <Bar className="h-4 w-14" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </section>
+
+      <div className="overflow-hidden rounded-lg border border-bd bg-bg-subtle">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 border-b border-bd-subtle p-4 last:border-b-0">
+            <Bar className="h-4 w-4" />
+            <div className="flex-1 space-y-2">
+              <Bar className="h-4 w-1/3" />
+              <Bar className="h-3 w-1/2" />
+            </div>
+            <Bar className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/collection/timeline/error.tsx
+++ b/app/collection/timeline/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+import RouteError from "@/components/ErrorBoundaryClient";
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <RouteError error={error} reset={reset} title="Timeline failed to load" />;
+}

--- a/app/collection/timeline/loading.tsx
+++ b/app/collection/timeline/loading.tsx
@@ -1,0 +1,57 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="p-4 md:p-6 max-w-6xl mx-auto" aria-busy="true" aria-label="Loading timeline">
+      <Bar className="h-4 w-24 mb-3" />
+      <header className="mb-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Bar className="mb-2 h-8 w-56" />
+            <Bar className="h-4 w-[26rem] max-w-full" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Bar className="h-8 w-28 rounded-md" />
+            <Bar className="h-8 w-40 rounded-md" />
+          </div>
+        </div>
+      </header>
+
+      <div className="mb-6 flex items-center gap-2 overflow-hidden">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Bar key={i} className="h-7 w-24 rounded-md" />
+        ))}
+      </div>
+
+      <section className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-bd-subtle bg-bg-subtle/30 p-3 space-y-2">
+            <Bar className="h-3 w-20" />
+            <Bar className="h-6 w-16" />
+            <Bar className="h-3 w-24" />
+          </div>
+        ))}
+      </section>
+
+      <section className="card p-5 mb-6">
+        <Bar className="h-4 w-32 mb-4" />
+        <Bar className="h-40 w-full" />
+      </section>
+
+      <div className="overflow-hidden rounded-lg border border-bd bg-bg-subtle">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 border-b border-bd-subtle p-4 last:border-b-0">
+            <Bar className="h-4 w-4" />
+            <div className="flex-1 space-y-2">
+              <Bar className="h-4 w-1/3" />
+              <Bar className="h-3 w-1/2" />
+            </div>
+            <Bar className="h-4 w-12" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/live/loading.tsx
+++ b/app/live/loading.tsx
@@ -1,0 +1,39 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-7xl p-4 md:p-6" aria-busy="true" aria-label="Loading live sessions">
+      <header className="mb-6">
+        <Bar className="mb-2 h-8 w-64" />
+        <Bar className="h-4 w-96 max-w-full" />
+      </header>
+      <section className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-bd-subtle bg-bg-subtle/30 p-3 space-y-2">
+            <Bar className="h-3 w-20" />
+            {Array.from({ length: 3 }).map((_, j) => (
+              <div key={j} className="flex items-center justify-between gap-2">
+                <Bar className="h-3 w-24" />
+                <Bar className="h-4 w-12" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </section>
+      <div className="overflow-hidden rounded-lg border border-bd bg-bg-subtle">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 border-b border-bd-subtle p-4 last:border-b-0">
+            <Bar className="h-4 w-4" />
+            <div className="flex-1 space-y-2">
+              <Bar className="h-4 w-1/3" />
+              <Bar className="h-3 w-1/2" />
+            </div>
+            <Bar className="h-4 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,102 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="p-6 md:p-8 max-w-7xl mx-auto" aria-busy="true" aria-label="Loading dashboard">
+      <header className="mb-6 -mx-6 md:-mx-8 -mt-6 md:-mt-8 px-6 md:px-8 py-6 border-b border-bd-subtle">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Bar className="h-8 w-48 mb-2" />
+            <Bar className="h-4 w-80" />
+          </div>
+          <Bar className="h-10 w-full sm:w-80 rounded-lg" />
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3 mb-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="card p-4">
+            <div className="flex items-center justify-between">
+              <Bar className="h-3 w-20" />
+              <Bar className="size-7 rounded-md" />
+            </div>
+            <Bar className="h-7 w-16 mt-2" />
+            <Bar className="h-3 w-24 mt-1.5" />
+          </div>
+        ))}
+      </section>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
+        <section className="card p-5 lg:col-span-2">
+          <div className="flex items-center justify-between mb-4">
+            <Bar className="h-4 w-56" />
+            <Bar className="h-3 w-20" />
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Bar className="size-4" />
+                <div className="flex-1 space-y-1.5">
+                  <Bar className="h-4 w-1/3" />
+                  <Bar className="h-3 w-1/2" />
+                </div>
+                <Bar className="h-4 w-14" />
+              </div>
+            ))}
+          </div>
+        </section>
+        <section className="card p-5">
+          <div className="flex items-center justify-between mb-4">
+            <Bar className="h-4 w-40" />
+            <Bar className="h-3 w-16" />
+          </div>
+          <Bar className="h-11 w-full mb-3" />
+          <div className="space-y-2 border-t border-bd/50 pt-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between gap-2">
+                <Bar className="h-3.5 flex-1" />
+                <Bar className="h-3.5 w-10" />
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <section className="card p-5 lg:col-span-2">
+          <div className="flex items-center justify-between mb-4">
+            <Bar className="h-4 w-32" />
+            <Bar className="h-3 w-16" />
+          </div>
+          <div className="space-y-1.5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="px-3 py-2.5 flex items-center gap-3">
+                <div className="flex-1 space-y-1.5 min-w-0">
+                  <Bar className="h-4 w-1/2" />
+                  <Bar className="h-3 w-2/3" />
+                </div>
+                <Bar className="h-6 w-16 rounded-full" />
+              </div>
+            ))}
+          </div>
+        </section>
+        <section className="card p-5">
+          <Bar className="h-4 w-28 mb-4" />
+          <div className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <Bar className="h-3.5 w-28" />
+                  <Bar className="h-3 w-6" />
+                </div>
+                <Bar className="h-1 w-full rounded-full" />
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/runs/loading.tsx
+++ b/app/runs/loading.tsx
@@ -1,0 +1,31 @@
+function Bar({ className }: { className: string }) {
+  return <div className={`shimmer rounded ${className}`} />;
+}
+
+export default function Loading() {
+  return (
+    <div className="p-8 max-w-6xl mx-auto" aria-busy="true" aria-label="Loading runs">
+      <header className="mb-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Bar className="mb-2 h-8 w-32" />
+            <Bar className="h-4 w-56" />
+          </div>
+          <Bar className="h-8 w-28 rounded-md" />
+        </div>
+      </header>
+      <div className="overflow-hidden rounded-lg border border-bd bg-bg-subtle">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 border-b border-bd-subtle p-4 last:border-b-0">
+            <div className="flex-1 space-y-2">
+              <Bar className="h-4 w-1/3" />
+              <Bar className="h-3 w-1/2" />
+            </div>
+            <Bar className="h-4 w-14" />
+            <Bar className="h-6 w-20 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds instant navigation feedback to every top-level route. All pages are `force-dynamic` with a synchronous 1-2s (cold: ~25s) server-side scan, so navigating froze on the previous page with zero feedback — the app previously had no `loading.tsx` files at all.

**New files only — zero edits to existing files** (no merge conflicts with sibling branches).

### Loading skeletons (7)
- `app/loading.tsx`, `app/live/loading.tsx`, `app/collection/loading.tsx`, `app/collection/timeline/loading.tsx`, `app/runs/loading.tsx`, `app/cases/loading.tsx`, `app/accuracy/loading.tsx`
- Each matches its page's real silhouette (container width/padding, header, stat-tile grid, table/list rows) using the existing `shimmer` + `card` visual language from `globals.css` (reduced-motion safe). Pure server-component markup, no client JS, no data fetching, existing Tailwind tokens only.

### Error boundaries (2)
- `app/collection/error.tsx`, `app/collection/timeline/error.tsx` — modeled byte-for-byte on `app/live/error.tsx` (`"use client"`, `{ error, reset }`, delegates to `ErrorBoundaryClient` with digest + retry). These were the only top-level routes without boundaries.

## Verification
- `tsc --noEmit`, `next lint` (zero warnings), full `npm test` — all green
- Dev server on :3104: all six routes return 200 full pages; the skeleton streams in the SSR shell (`shimmer` present in `/collection` HTML before hydrated content); no compile errors in dev log
- `scripts/public-upload-audit.sh` passes

## Notes
- Standard Next cascade semantics: child segments without their own `loading.tsx` (e.g. `/collection/session`, `/runs/[id]`) briefly show the nearest parent skeleton — cosmetic, and strictly better than a frozen screen. Follow-up files can refine those if desired.
- The collection/timeline pages currently catch scan errors in-page, so the new boundaries cover render throws and future regressions (removing the in-page catch becomes safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)