### PR TITLE
perf: timeline insights — binary-search marker windows, sliding-window medians (~10x on impact + series stages)

### DIFF
--- a/lib/insights/timeline.ts
+++ b/lib/insights/timeline.ts
@@ -32,9 +32,41 @@ export interface Marker {
 
 const median = (xs: number[]): number => {
   if (xs.length === 0) return 0;
+  if (xs.length === 1) return xs[0];
+  if (xs.length === 2) return (xs[0] + xs[1]) / 2; // sum is order-independent — no sort needed
   const s = [...xs].sort((a, b) => a - b);
   const m = Math.floor(s.length / 2);
   return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+/** First index in `points` (sorted ascending by `at`) whose `at` is >= t. */
+const lowerBoundAt = (points: SessionPoint[], t: number): number => {
+  let lo = 0, hi = points.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (points[mid].at < t) lo = mid + 1; else hi = mid;
+  }
+  return lo;
+};
+
+/** Insert v into an ascending-sorted array, keeping it sorted. */
+const insertSorted = (arr: number[], v: number): void => {
+  let lo = 0, hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] <= v) lo = mid + 1; else hi = mid;
+  }
+  arr.splice(lo, 0, v);
+};
+
+/** Remove one occurrence of v (known to be present) from an ascending-sorted array. */
+const removeSorted = (arr: number[], v: number): void => {
+  let lo = 0, hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < v) lo = mid + 1; else hi = mid;
+  }
+  arr.splice(lo, 1);
 };
 
 const mode = <T>(xs: T[]): T | null => {
@@ -119,11 +151,41 @@ export interface SeriesPoint { at: number; value: number; n: number }
 
 /** Trailing-window median of a metric — smooths the noise of per-session values. */
 export function metricSeries(points: SessionPoint[], pick: (p: SessionPoint) => number, window = 15): SeriesPoint[] {
+  if (!Number.isInteger(window) || window < 1) {
+    // Degenerate windows: keep the original per-index semantics verbatim.
+    const out: SeriesPoint[] = [];
+    for (let i = 0; i < points.length; i++) {
+      const from = Math.max(0, i - window + 1);
+      const slice = points.slice(from, i + 1).map(pick);
+      out.push({ at: points[i].at, value: median(slice), n: slice.length });
+    }
+    return out;
+  }
+  // Sliding sorted window instead of a per-index slice+sort — O(N×window)
+  // element moves with no per-index array allocations.
   const out: SeriesPoint[] = [];
+  const vals: number[] = new Array(points.length);
+  const win: number[] = []; // sorted values of the current window (NaNs excluded)
+  let nanInWindow = 0;
   for (let i = 0; i < points.length; i++) {
-    const from = Math.max(0, i - window + 1);
-    const slice = points.slice(from, i + 1).map(pick);
-    out.push({ at: points[i].at, value: median(slice), n: slice.length });
+    const v = (vals[i] = pick(points[i]));
+    if (Number.isNaN(v)) nanInWindow++; else insertSorted(win, v);
+    const outIdx = i - window;
+    if (outIdx >= 0) {
+      const o = vals[outIdx];
+      if (Number.isNaN(o)) nanInWindow--; else removeSorted(win, o);
+    }
+    const n = i < window ? i + 1 : window;
+    let value: number;
+    if (nanInWindow === 0) {
+      const m = win.length >> 1;
+      value = win.length % 2 ? win[m] : (win[m - 1] + win[m]) / 2;
+    } else {
+      // NaN comparisons make sorted-window maintenance unreliable — recompute
+      // this index the original way so behavior is bit-identical.
+      value = median(vals.slice(i - n + 1, i + 1));
+    }
+    out.push({ at: points[i].at, value, n });
   }
   return out;
 }
@@ -176,10 +238,23 @@ export interface MarkerImpact {
  * Compare the `window` sessions just before a marker's adoption to the `window`
  * just after. Correlational only — so co-occurring changes (a model switch, thin
  * samples) are surfaced as confounds rather than hidden.
+ *
+ * `points` must be sorted ascending by `at` (as `toPoints` returns them): the
+ * before/after windows are taken as contiguous ranges around the marker's
+ * boundary index (binary search) instead of two full-array filters per marker.
  */
 export function markerImpact(points: SessionPoint[], marker: Marker, window = 20, minSamples = 5): MarkerImpact {
-  const before = points.filter((p) => p.at < marker.firstSeenAt).slice(-window);
-  const after = points.filter((p) => p.at >= marker.firstSeenAt).slice(0, window);
+  let before: SessionPoint[], after: SessionPoint[];
+  if (Number.isInteger(window) && window >= 1) {
+    const split = lowerBoundAt(points, marker.firstSeenAt); // first index with at >= firstSeenAt
+    before = points.slice(Math.max(0, split - window), split);
+    after = points.slice(split, split + window);
+  } else {
+    // Degenerate windows: keep the original filter+slice semantics verbatim
+    // (slice(-0) takes the whole prefix, fractional windows truncate).
+    before = points.filter((p) => p.at < marker.firstSeenAt).slice(-window);
+    after = points.filter((p) => p.at >= marker.firstSeenAt).slice(0, window);
+  }
   const { agg: a, outcomePool: poolBefore } = aggregate(before);
   const { agg: b, outcomePool: poolAfter } = aggregate(after);
   const deltas: MetricAgg = {

--- a/tests/insights-timeline-perf.test.ts
+++ b/tests/insights-timeline-perf.test.ts
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { toPoints, detectMarkers, metricSeries, markerImpact, type SessionPoint } from "../lib/insights/timeline";
+import type { LiveSession, OutcomeSignals } from "../lib/live";
+
+function session(over: Partial<LiveSession> & { startedAt: number }): LiveSession & { sourceLabel: string } {
+  const sig: OutcomeSignals = { userPositive: 0, userNegative: 0, rephrases: 0, errorTail: false, testsPassedTail: false, reworkFiles: 0 };
+  return {
+    sessionId: "s" + over.startedAt + "-" + Math.random().toString(36).slice(2, 6),
+    displayTitle: null, lastPromptPreview: null, project: "/p", model: "claude-opus-4-8",
+    lastEventAt: over.startedAt, durationMs: 60000,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, totalTokens: 0, costUsd: 0,
+    usageSegments: [], toolCalls: 0, toolErrors: 0, numTurns: 1, stopReason: null, isError: false,
+    pathBytes: 0, lineCount: 0, malformedLineCount: 0, thinkingBlocks: 0, textBlocks: 0, attachmentCount: 0,
+    queueOperationCount: 0, snapshotCount: 0, hookErrors: 0, messageCount: 1, userType: null, dataQuality: 1,
+    metricSources: { model: "measured", tokens: "measured", cost: "inferred", duration: "measured", turns: "measured" },
+    parseWarnings: [], toolErrorRate: 0, toolCallsPerTurn: 0, textAvailability: 0, staleMs: 0,
+    traceGraph: { rootMessages: 0, sidechainMessages: 0, agentCount: 0, orphanMessages: 0 },
+    toolSummaries: [], toolDurations: [], queueSummary: { enqueue: 0, dequeue: 0, remove: 0, popAll: 0, preview: [] },
+    fileActivity: { touchedFiles: [], readLikeOperations: 0, writeLikeOperations: 0 },
+    modeSummary: { permissionModes: {}, gitBranch: null, entrypoint: null },
+    skillsUsed: [], mcpServersUsed: [], subagentSpawns: 0, cliVersion: null,
+    sourceLabel: "Claude Code",
+    ...over,
+    outcomeSignals: { ...sig, ...(over.outcomeSignals ?? {}) },
+  };
+}
+
+// mulberry32 — deterministic PRNG for the equivalence sweeps
+function rng(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+test("markerImpact boundary: points exactly at firstSeenAt land in `after`, not `before`", () => {
+  // Adoption at t=500; two sessions share that exact timestamp (one without the
+  // skill) — the `at >= firstSeenAt` side must absorb every tied point.
+  const pts = toPoints([
+    session({ startedAt: 100, costUsd: 1 }),
+    session({ startedAt: 200, costUsd: 1 }),
+    session({ startedAt: 300, costUsd: 1 }),
+    session({ startedAt: 500, costUsd: 9 }), // tied with adoption, no skill
+    session({ startedAt: 500, costUsd: 9, skillsUsed: ["boundary-skill"] }),
+    session({ startedAt: 600, costUsd: 9, skillsUsed: ["boundary-skill"] }),
+    session({ startedAt: 700, costUsd: 9, skillsUsed: ["boundary-skill"] }),
+  ]);
+  const marker = detectMarkers(pts).find((m) => m.name === "boundary-skill")!;
+  assert.equal(marker.firstSeenAt, 500);
+  const impact = markerImpact(pts, marker, 20, 3);
+  assert.equal(impact.nBefore, 3); // 100, 200, 300 only
+  assert.equal(impact.nAfter, 4); // both t=500 points plus 600, 700
+  assert.equal(impact.before.costUsd, 1);
+  assert.equal(impact.after.costUsd, 9);
+});
+
+test("markerImpact matches the filter-based reference on a randomized corpus", () => {
+  const r = rng(42);
+  const sessions = [];
+  for (let i = 0; i < 400; i++) {
+    // Coarse buckets force many duplicate timestamps at marker boundaries.
+    sessions.push(session({
+      startedAt: 1000 + Math.floor(r() * 80) * 50,
+      costUsd: r() * 5,
+      toolErrorRate: r() * 0.5,
+      skillsUsed: r() < 0.3 ? [`sk-${Math.floor(r() * 12)}`] : [],
+      subagentSpawns: r() < 0.2 ? 1 : 0,
+    }));
+  }
+  const pts = toPoints(sessions);
+  const reference = (points: SessionPoint[], firstSeenAt: number, window: number) => ({
+    before: points.filter((p) => p.at < firstSeenAt).slice(-window),
+    after: points.filter((p) => p.at >= firstSeenAt).slice(0, window),
+  });
+  for (const marker of detectMarkers(pts)) {
+    for (const window of [0, 1, 5, 20]) {
+      const impact = markerImpact(pts, marker, window, 3);
+      const ref = reference(pts, marker.firstSeenAt, window);
+      assert.equal(impact.nBefore, ref.before.length, `${marker.name} w=${window} before`);
+      assert.equal(impact.nAfter, ref.after.length, `${marker.name} w=${window} after`);
+      assert.deepEqual(
+        [impact.judgedBefore, impact.judgedAfter],
+        [ref.before.filter((p) => p.outcomeProvenance === "judged").length,
+         ref.after.filter((p) => p.outcomeProvenance === "judged").length],
+      );
+    }
+  }
+});
+
+test("metricSeries matches the naive slice-median reference on a randomized corpus", () => {
+  const r = rng(7);
+  const sessions = [];
+  for (let i = 0; i < 300; i++) {
+    sessions.push(session({ startedAt: 1000 + Math.floor(r() * 200) * 10, costUsd: r() * 10 }));
+  }
+  const pts = toPoints(sessions);
+  const median = (xs: number[]) => {
+    if (xs.length === 0) return 0;
+    const s = [...xs].sort((a, b) => a - b);
+    const m = Math.floor(s.length / 2);
+    return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+  };
+  for (const window of [0, 1, 3, 15, 1000]) {
+    const got = metricSeries(pts, (p) => p.costUsd, window);
+    const want = pts.map((p, i) => {
+      const slice = pts.slice(Math.max(0, i - window + 1), i + 1).map((q) => q.costUsd);
+      return { at: p.at, value: median(slice), n: slice.length };
+    });
+    assert.deepEqual(got, want, `window=${window}`);
+  }
+
+  // NaN metric values must take the recompute fallback and still match the
+  // naive reference — including windows where NaNs enter and later leave.
+  const nanPick = (p: SessionPoint) => (p.costUsd < 2 ? NaN : p.costUsd);
+  for (const window of [3, 15]) {
+    const got = metricSeries(pts, nanPick, window);
+    const want = pts.map((p, i) => {
+      const slice = pts.slice(Math.max(0, i - window + 1), i + 1).map(nanPick);
+      return { at: p.at, value: median(slice), n: slice.length };
+    });
+    assert.ok(got.some((s) => Number.isNaN(s.value)), `window=${window} exercises NaN windows`);
+    assert.ok(got.some((s, i) => i > window && !Number.isNaN(s.value)), `window=${window} recovers after NaNs leave`);
+    assert.deepEqual(got, want, `window=${window} with NaN values`);
+  }
+});


### PR DESCRIPTION
## What

`buildTimeline`'s post-parse hot spots in `lib/insights/timeline.ts`:

- **`markerImpact`**: replaced the two full-array `filter` passes per marker (O(markers × N)) with one binary search for the marker's boundary index (first point with `at >= firstSeenAt`) plus two contiguous `slice`s — valid because `toPoints` returns points sorted by `at`. Boundary semantics (`<` before / `>=` after, ties land in `after`) replicated exactly. Degenerate windows (< 1 or fractional) keep the old filter+slice path verbatim.
- **`metricSeries`**: replaced the per-index `slice` + `map` + copy-sort median (O(N × window log window) with per-index allocations) with a sliding sorted window (binary insert/remove, direct median read). Windows containing NaN fall back to the original slice+sort so behavior stays bit-identical; degenerate windows keep the original loop.
- **`median`**: length-1/2 fast paths (sum is order-independent — no sort needed).

## Equivalence gate

Harness (uncommitted, in `.test-data/`): 6,000 seeded synthetic sessions → `toPoints` → `detectMarkers` (164 markers) → all `markerImpact`s at windows 20 and 7 → five `metricSeries` (windows 1/3/15/100000). `sha256(JSON.stringify(report))` **identical before and after**: `02c53a3795294940e4921698c063efbee0ba32351a71a3c7038e633fb046a77f` (verified with alternating stash/pop runs).

## Measured (loaded machine — 6 parallel agents; alternating runs)

| Stage | Before | After |
|---|---|---|
| impacts, 164 markers, w=20 | 43.5 / 63.1 / 56.3 ms | 4.0 / 4.3 / 4.5 ms |
| metricSeries w=15, 6k points | 12.1 / 8.4 / 22.1 ms | 1.1 / 1.5 / 2.5 ms |
| harness full pass (incl. w=100k stress series) | 8.7 s | 22 ms |

E2E on the operator's real corpus (1,282 sessions): warm `/api/collection/timeline` returns sane JSON (106 markers, 28 impacts, 80 series points, 12 change points) in ~0.2–0.4 s.

## Tests

New `tests/insights-timeline-perf.test.ts`: pins marker-boundary tie semantics (points exactly at `firstSeenAt` go to `after`), randomized equivalence sweeps against the old filter/slice reference (windows 0/1/5/20 for `markerImpact`, 0/1/3/15/1000 for `metricSeries`), and NaN-window fallback coverage. Full suite green, `tsc --noEmit` clean, lint zero-warning, `scripts/public-upload-audit.sh` passed. `PARSER_VERSION` untouched.

## Out of scope, noted for follow-up

`lib/insights/judge.ts` (lines ~139–140 and ~300–301) still uses the same per-marker `filter(...).slice(...)` window pattern this PR removed from `markerImpact` — same O(markers × N) cost in the judge sampling path. Not touched here (file owned by another unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)