### PR TITLE
perf: shared full-history parse + corpus-fingerprint memo for Collection/home/timeline

### DIFF
--- a/app/api/collection/route.ts
+++ b/app/api/collection/route.ts
@@ -23,6 +23,8 @@ export async function GET(request: Request) {
     );
   }
 
+  // fresh = revalidate the corpus fingerprint NOW (skip the anti-stat-storm
+  // window); it re-parses only if the fingerprint actually changed.
   const data = scanAllSources(limit, { fresh: true });
   return NextResponse.json(
     data,

--- a/app/api/collection/timeline/route.ts
+++ b/app/api/collection/timeline/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
+import { collectAllSessions } from "@/lib/collection/aggregate";
 import { buildTimeline } from "@/lib/insights/collect";
 
 export const dynamic = "force-dynamic";
 
 /** Longitudinal report: adoption markers + before/after impact + outcome trend. */
 export async function GET() {
-  const data = buildTimeline();
+  const data = buildTimeline(collectAllSessions());
   return NextResponse.json(
     data,
     { headers: { "Cache-Control": "private, max-age=30, stale-while-revalidate=120" } },

--- a/app/collection/page.tsx
+++ b/app/collection/page.tsx
@@ -1,5 +1,5 @@
 import CollectionClient from "@/components/CollectionClient";
-import { scanAllSources, type AllSourcesResult } from "@/lib/collection/aggregate";
+import { collectAllSessions, scanAllSources, type AllSourcesResult } from "@/lib/collection/aggregate";
 import { buildRollup, type RollupReport } from "@/lib/collection/rollup";
 
 export const dynamic = "force-dynamic";
@@ -23,6 +23,8 @@ export default async function CollectionPage({ searchParams }: { searchParams?: 
     };
   }
   let rollup: RollupReport | undefined;
-  try { rollup = buildRollup(); } catch {}
+  // Reuse the request's shared parse (same fingerprint-memoized snapshot as
+  // scanAllSources above) instead of re-collecting every source.
+  try { rollup = buildRollup(collectAllSessions()); } catch {}
   return <CollectionClient initialData={data} error={error} initialQuery={q} rollup={rollup} />;
 }

--- a/app/collection/timeline/page.tsx
+++ b/app/collection/timeline/page.tsx
@@ -1,4 +1,5 @@
 import TimelineClient from "@/components/TimelineClient";
+import { collectAllSessions } from "@/lib/collection/aggregate";
 import { buildTimeline, type TimelineReport } from "@/lib/insights/collect";
 
 export const dynamic = "force-dynamic";
@@ -7,7 +8,7 @@ export default async function TimelinePage() {
   let data: TimelineReport;
   let error: string | undefined;
   try {
-    data = buildTimeline();
+    data = buildTimeline(collectAllSessions());
   } catch (e) {
     error = e instanceof Error ? e.message : String(e);
     data = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import clsx from "clsx";
 import { countRuns, listRuns } from "@/lib/db";
 import { loadCases } from "@/lib/cases";
-import { scanAllSources, type AllSourcesResult } from "@/lib/collection/aggregate";
+import { collectAllSessions, scanAllSources, type AllSourcesResult } from "@/lib/collection/aggregate";
 import { buildTimeline, type TimelineReport } from "@/lib/insights/collect";
 import StatusBadge from "@/components/StatusBadge";
 import HarnessBadge from "@/components/HarnessBadge";
@@ -40,7 +40,9 @@ export default async function Page() {
   let collection: AllSourcesResult | null = null;
   let timeline: TimelineReport | null = null;
   try { collection = scanAllSources(12); } catch {}
-  try { timeline = buildTimeline(); } catch {}
+  // Same fingerprint-memoized snapshot as scanAllSources — the timeline no
+  // longer re-parses the full history on every dashboard render.
+  try { timeline = buildTimeline(collectAllSessions()); } catch {}
 
   const byCat = cases.reduce<Record<string, number>>((a, c) => { a[c.category] = (a[c.category] || 0) + 1; return a; }, {});
   const recentSessions = collection?.sessions.slice(0, 6) ?? [];

--- a/lib/collection/aggregate.ts
+++ b/lib/collection/aggregate.ts
@@ -1,6 +1,7 @@
-import { scanSourceSessions, type LiveAggregate, type LiveSession } from "../live";
-import { allCollectionSources, defToSpec } from "./sources";
-import { discoverKnownSources, discoverUnknownCandidates, type UnknownCandidate } from "./discover";
+import crypto from "node:crypto";
+import { collectSourceSessions, scanSourceSessions, type LiveAggregate, type LiveSession } from "../live";
+import { allCollectionSources, defToSpec, type CollectionSourceDef } from "./sources";
+import { discoverKnownSources, discoverUnknownCandidates, type DiscoveredSource, type UnknownCandidate } from "./discover";
 import { displayModelId, PRICING_LIST_DATE, PRICING_SOURCE } from "../pricing";
 
 export interface CollectedSourceSummary {
@@ -193,8 +194,7 @@ const FULL_HISTORY = 100_000;
 /** Sessions retained in the memoized result; per-call `limit` slices down from this. */
 const SESSION_ITEM_CAP = 10_000;
 
-function computeAllSources(): AllSourcesResult {
-  const discovered = discoverKnownSources();
+function computeAllSources(discovered: DiscoveredSource[]): AllSourcesResult {
   const byId = new Map(discovered.map((d) => [d.id, d]));
 
   const summaries: CollectedSourceSummary[] = [];
@@ -202,7 +202,7 @@ function computeAllSources(): AllSourcesResult {
   const modelLists: ModelRollup[][] = [];
   const toolLists: ToolRollup[][] = [];
 
-  for (const def of allCollectionSources()) {
+  for (const def of hooks.sources()) {
     const disc = byId.get(def.id);
     const base: CollectedSourceSummary = {
       id: def.id,
@@ -273,7 +273,7 @@ function computeAllSources(): AllSourcesResult {
 
   // Unknown candidates: exclude every known root from the heuristic scan.
   const knownRoots = discovered.flatMap((d) => d.roots);
-  const unknown = discoverUnknownCandidates(knownRoots);
+  const unknown = hooks.unknown(knownRoots);
 
   return {
     generatedAtMs: Date.now(),
@@ -303,25 +303,134 @@ function computeAllSources(): AllSourcesResult {
   };
 }
 
-/**
- * Full discovery + scan is 0.4–2s and runs synchronously inside server-
- * component renders, so consecutive page loads share one result for a few
- * seconds. Callers that must observe the latest files (the scan API) pass
- * `fresh: true` to bypass and re-prime the memo.
- */
-const SCAN_MEMO_TTL_MS = 5_000;
+/** A parsed session tagged with the source it came from. */
+export type CollectedSession = LiveSession & { sourceId: string; sourceLabel: string };
 
-let scanMemo: { at: number; result: AllSourcesResult } | null = null;
+interface CollectionSnapshot {
+  fingerprint: string;
+  result: AllSourcesResult;
+  /** Full history of every parseable source (archived included), source-tagged. */
+  sessions: CollectedSession[];
+}
+
+/**
+ * Concurrent requests within this window share the last fingerprint check
+ * instead of re-statting every session file per request. `fresh: true`
+ * bypasses it (revalidate NOW) — it does not force a recompute.
+ */
+const FINGERPRINT_TTL_MS = 3_000;
+
+/**
+ * Test seams (the `_setCacheDbForTest` pattern): the real source registry and
+ * discovery walk both point at fixed home-dir roots, so memo behavior is only
+ * testable by injecting temp-dir equivalents.
+ */
+interface CollectionHooks {
+  discover: () => DiscoveredSource[];
+  sources: () => CollectionSourceDef[];
+  unknown: (knownRoots: string[]) => UnknownCandidate[];
+  /** Test-only override; production always uses FINGERPRINT_TTL_MS. */
+  fingerprintTtlMs?: number;
+}
+
+const DEFAULT_HOOKS: CollectionHooks = {
+  discover: discoverKnownSources,
+  sources: allCollectionSources,
+  unknown: discoverUnknownCandidates,
+};
+
+let hooks: CollectionHooks = DEFAULT_HOOKS;
+
+export function _setCollectionHooksForTest(overrides: Partial<CollectionHooks> | null): void {
+  hooks = overrides ? { ...DEFAULT_HOOKS, ...overrides } : DEFAULT_HOOKS;
+  snapshot = null;
+  lastValidatedAt = 0;
+}
+
+/**
+ * Corpus identity from the discovery walk (which already stats every session
+ * file): per-source status plus every file's (path, mtime, size). Any file
+ * added, removed, renamed, touched, or resized changes the fingerprint; an
+ * unchanged fingerprint proves the memoized parse still matches the disk.
+ */
+export function fingerprintDiscovery(discovered: DiscoveredSource[]): string {
+  const h = crypto.createHash("sha256");
+  for (const d of discovered) {
+    h.update(`${d.id} ${d.status} ${d.sessionCount} ${d.lastActivityMs ?? -1}`);
+    if (d.collected) {
+      const files = [...d.collected.files].sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
+      for (const f of files) h.update(`${f.file} ${f.mtime} ${f.size}`);
+    }
+  }
+  return h.digest("hex");
+}
+
+/**
+ * Full discovery + parse is 0.4–2s+ and runs synchronously inside server-
+ * component renders — and one render used to run it up to three times
+ * (sources scan, rollup, timeline). Instead of a blind 5s TTL, the memo is
+ * keyed by the corpus fingerprint: each request re-runs only the cheap
+ * discovery stat pass and serves the memoized parse while the fingerprint
+ * matches. Memoized data is never served across a fingerprint change.
+ */
+let snapshot: CollectionSnapshot | null = null;
+let lastValidatedAt = 0;
+
+function getSnapshot(opts: { fresh?: boolean } = {}): CollectionSnapshot {
+  const now = Date.now();
+  const ttlMs = hooks.fingerprintTtlMs ?? FINGERPRINT_TTL_MS;
+  if (!opts.fresh && snapshot && now - lastValidatedAt < ttlMs) return snapshot;
+  const discovered = hooks.discover();
+  const fingerprint = fingerprintDiscovery(discovered);
+  if (!snapshot || snapshot.fingerprint !== fingerprint) {
+    snapshot = computeSnapshot(discovered, fingerprint);
+  } else if (opts.fresh) {
+    // Explicit rescan with an unchanged corpus: the parse memo stands, but the
+    // unknown-candidate walk covers dirs OUTSIDE the fingerprint — re-run it so
+    // a newly installed agent CLI still surfaces without a known-source change.
+    const unknown = hooks.unknown(discovered.flatMap((d) => d.roots));
+    snapshot = { ...snapshot, result: { ...snapshot.result, unknown } };
+  }
+  lastValidatedAt = now;
+  return snapshot;
+}
+
+function computeSnapshot(discovered: DiscoveredSource[], fingerprint: string): CollectionSnapshot {
+  // Aggregate first: scanSourceSessions primes the per-file session cache, so
+  // the full-history collection below re-reads no transcript bytes. The
+  // collection deliberately covers every parseable def — not just "present"
+  // ones — because archived sessions of a since-deleted root still live in
+  // the parse cache and must keep feeding rollup/timeline (as they did when
+  // those callers collected for themselves).
+  const result = computeAllSources(discovered);
+  const sessions: CollectedSession[] = [];
+  for (const def of hooks.sources()) {
+    if (!def.parseable) continue;
+    for (const s of collectSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true })) {
+      sessions.push({ ...s, sourceId: def.id, sourceLabel: def.label });
+    }
+  }
+  return { fingerprint, result, sessions };
+}
 
 function withLimit(result: AllSourcesResult, limit: number): AllSourcesResult {
-  return { ...result, sessions: result.sessions.slice(0, limit) };
+  // Restamp the reference time on every serve: the memo can outlive the old
+  // 5s TTL by minutes, and relative "x ago" labels must not freeze with it.
+  return { ...result, generatedAtMs: Date.now(), sessions: result.sessions.slice(0, limit) };
 }
 
 export function scanAllSources(limit = 200, opts: { fresh?: boolean } = {}): AllSourcesResult {
-  if (!opts.fresh && scanMemo && Date.now() - scanMemo.at < SCAN_MEMO_TTL_MS) {
-    return withLimit(scanMemo.result, limit);
-  }
-  const result = computeAllSources();
-  scanMemo = { at: Date.now(), result };
-  return withLimit(result, limit);
+  return withLimit(getSnapshot(opts).result, limit);
+}
+
+/**
+ * The shared full-history session collection (archived included), parsed at
+ * most once per corpus fingerprint. Collection/home/timeline callers pass
+ * this to `buildRollup` / `buildTimeline` so one request never parses the
+ * session history more than once.
+ */
+export function collectAllSessions(opts: { fresh?: boolean } = {}): CollectedSession[] {
+  // Copy the array (not the sessions): an in-place sort/splice by a caller
+  // must never reorder the memoized snapshot served to other requests.
+  return [...getSnapshot(opts).sessions];
 }

--- a/lib/insights/collect.ts
+++ b/lib/insights/collect.ts
@@ -32,17 +32,25 @@ function downsample<T>(xs: T[], max: number): T[] {
   return out;
 }
 
+/** Session shape the timeline needs: a parsed session tagged with its source. */
+export type TimelineSession = LiveSession & { sourceLabel: string };
+
 /**
  * Full-history points + markers with persisted judge verdicts blended in.
  * Shared by the report builder and the judging pass (which needs the same
- * points to pick its sample).
+ * points to pick its sample). Pass `sessionsIn` (e.g. from
+ * `collectAllSessions()`) to reuse an already-parsed collection; judgments
+ * are still loaded fresh on every call.
  */
-export function collectAllPoints(limitPerSource = 100_000): { points: SessionPoint[]; markers: Marker[] } {
-  const sessions: Array<LiveSession & { sourceLabel: string }> = [];
-  for (const def of allCollectionSources()) {
-    if (!def.parseable) continue;
-    for (const s of collectSourceSessions(defToSpec(def), limitPerSource, { includeArchived: true })) {
-      sessions.push({ ...s, sourceLabel: def.label });
+export function collectAllPoints(sessionsIn?: TimelineSession[], limitPerSource = 100_000): { points: SessionPoint[]; markers: Marker[] } {
+  let sessions = sessionsIn;
+  if (!sessions) {
+    sessions = [];
+    for (const def of allCollectionSources()) {
+      if (!def.parseable) continue;
+      for (const s of collectSourceSessions(defToSpec(def), limitPerSource, { includeArchived: true })) {
+        sessions.push({ ...s, sourceLabel: def.label });
+      }
     }
   }
   const points = toPoints(sessions, loadCurrentJudgments());
@@ -55,8 +63,8 @@ export function collectAllPoints(limitPerSource = 100_000): { points: SessionPoi
  * overall outcome trend. Heavy on a cold cache; the per-file session cache makes
  * repeat calls cheap.
  */
-export function buildTimeline(limitPerSource = 100_000): TimelineReport {
-  const { points, markers } = collectAllPoints(limitPerSource);
+export function buildTimeline(sessionsIn?: TimelineSession[]): TimelineReport {
+  const { points, markers } = collectAllPoints(sessionsIn);
 
   const withSignal = points.filter((p) => p.outcomeHasSignal);
   const half = Math.floor(withSignal.length / 2);

--- a/tests/collection.test.ts
+++ b/tests/collection.test.ts
@@ -4,10 +4,12 @@ import Database from "better-sqlite3";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { allCollectionSources, defToSpec, KNOWN_COLLECTION_SOURCES } from "../lib/collection/sources";
-import { looksLikeTranscriptFile } from "../lib/collection/discover";
+import { allCollectionSources, defToSpec, KNOWN_COLLECTION_SOURCES, type CollectionSourceDef } from "../lib/collection/sources";
+import { looksLikeTranscriptFile, type DiscoveredSource } from "../lib/collection/discover";
 import { _setCacheDbForTest } from "../lib/live-cache";
-import { scanSourceSessions } from "../lib/live";
+import { collectSourceFiles, scanSourceSessions } from "../lib/live";
+import { _setCollectionHooksForTest, collectAllSessions, fingerprintDiscovery, scanAllSources } from "../lib/collection/aggregate";
+import { buildRollup } from "../lib/collection/rollup";
 
 // Every scan goes through the live-cache; use a file-level in-memory DB so
 // parallel test processes never race on the shared .test-data SQLite cache.
@@ -330,6 +332,138 @@ test("collection model rollups sanitize local model paths and expose pricing evi
   assert.equal((agg.byModel[0] as any).familyRateSessions, 1);
   assert.equal((agg.byModel[0] as any).listedRateSessions, 0);
   assert.equal((agg.usageSummary as any).sessionsWithPricedUsage, 1);
+});
+
+// ---- corpus-fingerprint memo (scanAllSources / collectAllSessions) ----
+
+function writeSessionFile(dir: string, name: string, sessionId: string, extraText = "done"): void {
+  fs.writeFileSync(
+    path.join(dir, name),
+    [
+      { type: "system", sessionId, cwd: "/tmp/proj", timestamp: "2026-06-28T20:00:00.000Z" },
+      { type: "assistant", message: { content: [{ type: "text", text: extraText }] } },
+      { type: "result", duration_ms: 1000, num_turns: 1, usage: { input_tokens: 10, output_tokens: 5 } },
+    ].map((l) => JSON.stringify(l)).join("\n"),
+    "utf8",
+  );
+}
+
+/** Hooks that mirror discoverKnownSources for one temp-dir source. */
+function memoTestHooks(def: CollectionSourceDef, ttlMs: number, unknownDirs: string[] = []) {
+  const discover = (): DiscoveredSource[] => {
+    const collected = collectSourceFiles(defToSpec(def));
+    let lastActivityMs: number | null = null;
+    for (const f of collected.files) {
+      if (lastActivityMs == null || f.mtime > lastActivityMs) lastActivityMs = f.mtime;
+    }
+    return [{
+      id: def.id, label: def.label, format: def.format, parseable: def.parseable,
+      roots: def.roots, presentRoots: def.roots,
+      sessionCount: collected.files.length, lastActivityMs,
+      status: collected.files.length > 0 ? "present" : "empty",
+      collected,
+    }];
+  };
+  const unknown = () => unknownDirs.map((dir) => ({
+    dir, displayDir: dir, sampleFile: path.join(dir, "s.jsonl"), fileCount: 1, reason: "test",
+  }));
+  return { discover, sources: () => [def], unknown, fingerprintTtlMs: ttlMs };
+}
+
+test("scanAllSources memo serves cached parse while the corpus fingerprint is unchanged", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-memo-"));
+  const def: CollectionSourceDef = { id: "memo-src", label: "Memo Src", roots: [dir], format: "jsonl-dir", parseable: true };
+  writeSessionFile(dir, "a.jsonl", "memo-a");
+  // Long TTL so only explicit `fresh` revalidates; the fingerprint check itself
+  // is what these assertions target.
+  const unknownDirs: string[] = [];
+  _setCollectionHooksForTest(memoTestHooks(def, 60_000, unknownDirs));
+  try {
+    const r1 = scanAllSources(50);
+    assert.equal(r1.totalParsedSessions, 1);
+    assert.equal(r1.sessions[0].sessionId, "memo-a");
+
+    // fresh → fingerprint revalidated; unchanged files → memoized objects served.
+    const r2 = scanAllSources(50, { fresh: true });
+    assert.equal(r2.totalParsedSessions, 1);
+    assert.equal(r2.sessions[0], r1.sessions[0], "unchanged fingerprint must serve the memoized parse");
+
+    // The shared full-history collection rides the same snapshot.
+    const shared = collectAllSessions({ fresh: true });
+    assert.equal(shared.length, 1);
+    assert.equal(shared[0].sourceId, "memo-src");
+    assert.equal(shared[0].sourceLabel, "Memo Src");
+    assert.equal(collectAllSessions({ fresh: true })[0], shared[0]);
+    assert.equal(buildRollup(shared).heatmapSessions, 1);
+
+    // A fresh rescan with an unchanged corpus must still refresh the
+    // unknown-candidate walk (its dirs live outside the fingerprint).
+    unknownDirs.push("/tmp/new-agent");
+    assert.equal(scanAllSources(50).unknown.length, 0, "non-fresh within TTL keeps the memoized unknown list");
+    const r3 = scanAllSources(50, { fresh: true });
+    assert.equal(r3.unknown.length, 1);
+    assert.equal(r3.unknown[0].dir, "/tmp/new-agent");
+    assert.equal(r3.sessions[0], r1.sessions[0], "parse memo must survive an unknown-only refresh");
+  } finally {
+    _setCollectionHooksForTest(null);
+  }
+});
+
+test("scanAllSources memo invalidates when a session file is added or changes size", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-memo-inv-"));
+  const def: CollectionSourceDef = { id: "memo-inv", label: "Memo Inv", roots: [dir], format: "jsonl-dir", parseable: true };
+  writeSessionFile(dir, "a.jsonl", "inv-a");
+  _setCollectionHooksForTest(memoTestHooks(def, 60_000));
+  try {
+    const r1 = scanAllSources(50);
+    assert.equal(r1.totalParsedSessions, 1);
+
+    // New file: within the TTL the memo is served stale (anti-stat-storm)…
+    writeSessionFile(dir, "b.jsonl", "inv-b");
+    assert.equal(scanAllSources(50).totalParsedSessions, 1);
+    // …but fresh revalidates the fingerprint and recomputes.
+    const r2 = scanAllSources(50, { fresh: true });
+    assert.equal(r2.totalParsedSessions, 2);
+    assert.equal(collectAllSessions().length, 2);
+
+    // Same file, different content/size: fingerprint changes again.
+    writeSessionFile(dir, "b.jsonl", "inv-b", "done with a longer final message");
+    const r3 = scanAllSources(50, { fresh: true });
+    assert.equal(r3.totalParsedSessions, 2);
+    const b3 = r3.sessions.find((s) => s.sessionId === "inv-b");
+    const b2 = r2.sessions.find((s) => s.sessionId === "inv-b");
+    assert.ok(b3 && b2 && b3 !== b2, "changed file must be re-parsed, not served from the memo");
+  } finally {
+    _setCollectionHooksForTest(null);
+  }
+});
+
+test("fingerprintDiscovery tracks file path, mtime, and size", () => {
+  const base: DiscoveredSource = {
+    id: "fp", label: "FP", format: "jsonl-dir", parseable: true,
+    roots: ["/tmp/fp"], presentRoots: ["/tmp/fp"],
+    sessionCount: 2, lastActivityMs: 2_000, status: "present",
+    collected: {
+      files: [
+        { file: "/tmp/fp/a.jsonl", project: "p", mtime: 1_000, size: 10 },
+        { file: "/tmp/fp/b.jsonl", project: "p", mtime: 2_000, size: 20 },
+      ],
+      scanWarnings: [],
+    },
+  };
+  const clone = (mutate: (d: DiscoveredSource) => void): DiscoveredSource => {
+    const d: DiscoveredSource = JSON.parse(JSON.stringify(base));
+    mutate(d);
+    return d;
+  };
+  const fp = fingerprintDiscovery([base]);
+  assert.equal(fingerprintDiscovery([clone(() => {})]), fp, "identical discovery → identical fingerprint");
+  // File order must not matter (walk order is fs-dependent).
+  assert.equal(fingerprintDiscovery([clone((d) => d.collected!.files.reverse())]), fp);
+  assert.notEqual(fingerprintDiscovery([clone((d) => { d.collected!.files[0].mtime = 1_001; })]), fp);
+  assert.notEqual(fingerprintDiscovery([clone((d) => { d.collected!.files[0].size = 11; })]), fp);
+  assert.notEqual(fingerprintDiscovery([clone((d) => { d.collected!.files[0].file = "/tmp/fp/renamed.jsonl"; })]), fp);
+  assert.notEqual(fingerprintDiscovery([clone((d) => { d.collected!.files.pop(); d.sessionCount = 1; })]), fp);
 });
 
 test("archived sessions are repriced from tokens instead of preserving stale cached estimates", () => {


### PR DESCRIPTION
## Problem

One `/collection` render parsed the full session history up to **three times**: `scanAllSources(80)` (5s-TTL memo), `buildRollup()` (ignored its `sessionsIn` param and re-collected every source), and on home, `buildTimeline()` (a third independent full parse with no memo at all). The API Rescan passed `fresh:true`, bypassing the memo entirely and forcing a full recompute on every hit.

## Change

- **`collectAllSessions()`** (lib/collection/aggregate.ts): shared, source-tagged full-history collection (archived included), computed once per corpus change. Home, `/collection`, `/collection/timeline`, and `/api/collection/timeline` now feed it to `buildRollup(sessionsIn)` and the new `buildTimeline(sessionsIn)` — 3 full parses per load → 1.
- **Corpus-fingerprint memo** replaces the blind 5s TTL: fingerprint = every known source file's `(path, mtime, size)` from the discovery walk (which already stats every file). Unchanged fingerprint → memoized parse served indefinitely; any file added/removed/renamed/touched/resized → recompute. Memoized data is never served across a fingerprint change.
- **`fresh:true` semantics**: now "revalidate the fingerprint NOW" (skips the 3s anti-stat-storm window), not "recompute unconditionally". A fresh rescan with an unchanged corpus still re-runs the unknown-candidate walk (its dirs live outside the fingerprint), so a newly installed agent CLI keeps surfacing — caught by code review, covered by a test.
- `generatedAtMs` restamped per serve so relative "x ago" labels stay accurate while the memo outlives the old 5s window (it is only consumed for relative-label rendering).
- Review fixes: `collectAllSessions` returns an array copy so callers can't reorder the memo; TTL override is test-only (`?? FINGERPRINT_TTL_MS`); dead `limitPerSource` dropped from `buildTimeline`; `collectAllPoints` param order aligned.

## Measured (real ~1.3k-session corpus, warm caches, dev server)

| Endpoint | HEAD | This PR |
| --- | --- | --- |
| `/collection` page, memo lapsed, corpus unchanged | 2.34s | **0.15s** |
| home page, memo lapsed, corpus unchanged | 1.63s | **0.09–0.15s** |
| `/collection` page, corpus actively changing between loads | 2.34s | ~1.5–1.75s (parse once, not 3×) |
| `/api/collection?limit=80` (`fresh:true`, warm) | 0.33–0.39s | 0.25–0.49s (recompute only on real change) |
| `/api/collection/timeline` (warm) | 60–84ms | **33–44ms** |

Sanity on the real corpus: totalParsedSessions 1282 (matches HEAD exactly), byModel 31, archived 51, identical response key sets.

## Gates

- `scripts/perf/equiv-scan.ts` hashes **identical** before/after (all 8 configs).
- `tsc --noEmit`, `next lint --max-warnings=0`, full `npm test` green; new tests cover memo-serve on unchanged fingerprint, invalidation on file add/size change, fingerprint sensitivity (path/mtime/size/order-independence), and the fresh-rescan unknown-candidate refresh.
- `PARSER_VERSION` untouched; `parseLiveSession` output unchanged.
- `bash scripts/public-upload-audit.sh` passed.

## Known limitation (needs lib/live.ts, out of this unit's scope)

On a fingerprint miss the snapshot still walks each source twice (`scanSourceSessions` for the aggregate + `collectSourceSessions` for the full list) because `live.ts`'s `aggregate()` is private and its session list is capped at 100. Exporting an aggregate-from-sessions path (or accepting `preCollected` in `collectSourceSessions`) would halve recompute cost — left for a live.ts-owning unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)