### PR TITLE
perf: memoize model→rate resolution in lib/pricing.ts (~8x, 26.3→3.2ms per 100k lookups)

### DIFF
--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -116,8 +116,7 @@ function familyRate(id: string): ListedRate | null {
   return null;
 }
 
-/** Resolve a rate for a real model id. Placeholder/sentinel ids stay unpriced. */
-export function rateForModelInfo(model: string | null | undefined): ModelRate | null {
+function resolveRateForModelInfo(model: string): ModelRate | null {
   if (isPlaceholderModel(model)) return null;
   const display = displayModelId(model);
   if (!display) return null;
@@ -127,6 +126,26 @@ export function rateForModelInfo(model: string | null | undefined): ModelRate | 
   const family = familyRate(id);
   if (family) return { rate: family.rate, exact: false, confidence: "family", sourceModel: family.sourceModel };
   return { rate: DEFAULT_RATE, exact: false, confidence: "fallback", sourceModel: "fallback" };
+}
+
+// Real transcript corpora contain only ~dozens of distinct model ids, so this
+// memo stays tiny; the cap only guards against a pathological corpus full of
+// fabricated model strings. Safe because the catalog above is a module-level
+// constant with no runtime mutation path. Cached ModelRate objects are shared
+// across calls (as their inner TokenRate already was) — callers must not
+// mutate them.
+const RATE_MEMO_MAX = 4096;
+const rateMemo = new Map<string, ModelRate | null>();
+
+/** Resolve a rate for a real model id. Placeholder/sentinel ids stay unpriced. */
+export function rateForModelInfo(model: string | null | undefined): ModelRate | null {
+  if (model == null) return null;
+  const cached = rateMemo.get(model);
+  if (cached !== undefined) return cached;
+  const resolved = resolveRateForModelInfo(model);
+  if (rateMemo.size >= RATE_MEMO_MAX) rateMemo.clear();
+  rateMemo.set(model, resolved);
+  return resolved;
 }
 
 export function rateForModel(model: string | null | undefined): TokenRate | null {

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -73,6 +73,34 @@ test("pricing reports listed, family-mapped, and fallback rate provenance", () =
   assert.equal(fallback?.exact, false);
 });
 
+test("memoized repeat lookups return identical results", () => {
+  const first = rateForModelInfo("claude-opus-4-8");
+  const second = rateForModelInfo("claude-opus-4-8");
+  assert.deepEqual(second, first);
+  assert.deepEqual(second, {
+    rate: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    exact: true,
+    confidence: "listed",
+    sourceModel: "anthropic/claude-opus-4.8",
+  });
+
+  const familyFirst = rateForModelInfo("/data/models/hf/zai-org__GLM-5.2-FP8");
+  assert.deepEqual(rateForModelInfo("/data/models/hf/zai-org__GLM-5.2-FP8"), familyFirst);
+  assert.equal(familyFirst?.confidence, "family");
+
+  // Unknown-model fallback is unchanged and stable across repeat lookups.
+  const unknownFirst = rateForModelInfo("some-unknown-model");
+  const unknownSecond = rateForModelInfo("some-unknown-model");
+  assert.deepEqual(unknownSecond, unknownFirst);
+  assert.deepEqual(unknownSecond?.rate, DEFAULT_RATE);
+  assert.equal(unknownSecond?.confidence, "fallback");
+
+  // Placeholder/null inputs stay unpriced on repeat calls too.
+  assert.equal(rateForModelInfo("<synthetic>"), null);
+  assert.equal(rateForModelInfo("<synthetic>"), null);
+  assert.equal(rateForModelInfo(null), null);
+});
+
 test("displayModelId removes host-specific model paths without inventing a different model", () => {
   assert.equal(displayModelId("/data/models/hf/zai-org__GLM-5.2-FP8"), "hf:zai-org/glm-5.2-fp8");
   assert.equal(displayModelId("gpt-5.6-luna"), "gpt-5.6-luna");


### PR DESCRIPTION
## What

Memoize the model→rate resolution inside `lib/pricing.ts`: the original `rateForModelInfo` body becomes a private `resolveRateForModelInfo`, and the exported function now serves from a module-level `Map<string, ModelRate | null>` keyed on the raw model-id string. This covers every hot caller — `estimateCostUsd`, `rateForModel`, `modelUsageCosts`/inferred-session-cost paths — which run per-session per-scan (thousands of lookups per page load at ~1.3k sessions), complementing the per-aggregate memo already in `lib/live.ts`.

Safety: verified the catalog (`LISTED_RATES`, `LISTED_BY_ALIAS`, `DEFAULT_RATE`) is a module-level constant with no reload/fetch path, no exported setters, and no env-dependent mutation — and tests never stub it — so a module-level memo cannot serve stale rates. Capped at 4096 entries (clear-on-overflow) purely as a guard against pathological corpora; real model-id cardinality is ~dozens. Cached `ModelRate` wrappers are shared across calls (their inner `TokenRate` already was); all callers were traced and are read-only.

## Benchmark

Alternating A/B (3 rounds each, loaded machine), N=100k `rateForModelInfo` calls over a realistic 14-id mix (listed, family-mapped, unknown-fallback, placeholder), median of 7 in-process runs per arm:

| round | before (HEAD) | after (memo) |
|---|---|---|
| 1 | 26.58 ms | 5.13 ms |
| 2 | 26.25 ms | 3.18 ms |
| 3 | 24.50 ms | 3.07 ms |

Median of medians: **26.25 ms → 3.18 ms per 100k calls (~8x)**.

## Gates

- **Cost-output equivalence**: `scripts/perf/equiv-scan.ts` hashes identical at HEAD vs patched (all 8 config rows, byte counts included).
- `npx tsc --noEmit`, `npm run lint` (zero warnings), `npm test` all green.
- New test: memoized repeat lookups are deep-equal (listed, family, unknown-fallback), and placeholder/null behavior is unchanged across repeat calls.
- `npm run pricing:check`: fails **identically at HEAD** — live OpenRouter rates for glm-5.2 / deepseek-v4-flash / kimi-k2.7-code drifted since PRICING_LIST_DATE (2026-07-15). Pre-existing, environmental, zero delta from this change; updating the catalog would change cost outputs and belongs in a separate rate-refresh PR.
- PARSER_VERSION untouched.

## E2E

Dev-server e2e intentionally skipped: this is a pure library-level change with no UI or parser surface; the equiv-scan hash gate exercises the integrated scan→aggregate→cost path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
