### PR TITLE
perf: limit-aware session retention (Collection can browse all ~1.3k sessions)

### DIFF
--- a/lib/collection/aggregate.ts
+++ b/lib/collection/aggregate.ts
@@ -194,9 +194,7 @@ const FULL_HISTORY = 100_000;
 /** Sessions retained in the memoized result; per-call `limit` slices down from this. */
 const SESSION_ITEM_CAP = 10_000;
 
-function computeAllSources(discovered: DiscoveredSource[]): AllSourcesResult {
-  const byId = new Map(discovered.map((d) => [d.id, d]));
-
+function computeAllSources(discovered: DiscoveredSource[], byId: Map<string, DiscoveredSource>): AllSourcesResult {
   const summaries: CollectedSourceSummary[] = [];
   const allSessions: CollectionSessionItem[] = [];
   const modelLists: ModelRollup[][] = [];
@@ -234,7 +232,9 @@ function computeAllSources(discovered: DiscoveredSource[]): AllSourcesResult {
     if (def.parseable && base.status === "present") {
       // Reuse discovery's walk (files + warnings) instead of re-walking the
       // whole source tree for the scan.
-      const agg: LiveAggregate = scanSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: disc?.collected });
+      // Retain up to SESSION_ITEM_CAP per source (not the default 100) so the
+      // memoized cross-source list can satisfy large ?limit= requests.
+      const agg: LiveAggregate = scanSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: disc?.collected, sessionRetention: SESSION_ITEM_CAP });
       base.archivedSessions = agg.archivedSessions;
       base.parsedSessions = agg.totalSessions;
       base.totalCostUsd = agg.totalCostUsd;
@@ -258,8 +258,9 @@ function computeAllSources(discovered: DiscoveredSource[]): AllSourcesResult {
       toolLists.push(agg.byTool.map((t) => ({ name: t.name, calls: t.calls, errors: t.errors })));
       base.avgDataQuality = agg.avgDataQuality;
       base.scanWarnings = agg.scanWarnings;
-      // Whole-history flag — agg.sessions is display-sliced to 100, so a
-      // `.some()` over it would miss estimated sessions past the slice.
+      // Whole-history flag — agg.sessions is retention-capped (SESSION_ITEM_CAP
+      // here), so a `.some()` over it could miss estimated sessions past the
+      // slice; totals likewise come from agg.total* scalars, never agg.sessions.
       base.costEstimated = agg.sessionsWithInferredCost > 0;
       for (const s of agg.sessions) {
         allSessions.push(toCollectionSessionItem(s, def.id, def.label));
@@ -402,11 +403,14 @@ function computeSnapshot(discovered: DiscoveredSource[], fingerprint: string): C
   // ones — because archived sessions of a since-deleted root still live in
   // the parse cache and must keep feeding rollup/timeline (as they did when
   // those callers collected for themselves).
-  const result = computeAllSources(discovered);
+  const byId = new Map(discovered.map((d) => [d.id, d]));
+  const result = computeAllSources(discovered, byId);
   const sessions: CollectedSession[] = [];
   for (const def of hooks.sources()) {
     if (!def.parseable) continue;
-    for (const s of collectSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true })) {
+    // Reuse discovery's walk here too — without it, every snapshot recompute
+    // walked each source tree a second time just to re-list the same files.
+    for (const s of collectSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: byId.get(def.id)?.collected })) {
       sessions.push({ ...s, sourceId: def.id, sourceLabel: def.label });
     }
   }

--- a/lib/live.ts
+++ b/lib/live.ts
@@ -312,9 +312,13 @@ export function collectSourceFiles(spec: CollectionSourceSpec): CollectedSourceF
   return { files, scanWarnings };
 }
 
-/** Scan one arbitrary collection source (any harness), reusing the harness path. */
-export function scanSourceSessions(spec: CollectionSourceSpec, limit = 200, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles } = {}): LiveAggregate {
-  return scanResolvedSource(specToSource(spec), limit, opts.includeArchived ?? false, opts.preCollected);
+/**
+ * Scan one arbitrary collection source (any harness), reusing the harness path.
+ * `sessionRetention` widens the aggregate's display-capped `sessions` field
+ * (default 100) for callers that browse full history; totals are unaffected.
+ */
+export function scanSourceSessions(spec: CollectionSourceSpec, limit = 200, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles; sessionRetention?: number } = {}): LiveAggregate {
+  return scanResolvedSource(specToSource(spec), limit, opts.includeArchived ?? false, opts.preCollected, opts.sessionRetention);
 }
 
 export function defaultLiveLimitForHarness(harness?: string): number {
@@ -820,17 +824,18 @@ function appendArchivedSessions(source: LiveTraceSource, sessions: LiveSession[]
 
 /**
  * Full parsed session list for a source, UNCAPPED (the aggregate's `sessions`
- * array is sliced to 100 for the live view; longitudinal analytics need them all).
+ * array is retention-capped for display; longitudinal analytics need them all).
+ * Pass `preCollected` (e.g. discovery's walk) to skip re-walking the tree.
  */
-export function collectSourceSessions(spec: CollectionSourceSpec, limit = 100_000, opts: { includeArchived?: boolean } = {}): LiveSession[] {
-  return parseSourceSessionList(specToSource(spec), limit, [], opts.includeArchived ?? false);
+export function collectSourceSessions(spec: CollectionSourceSpec, limit = 100_000, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles } = {}): LiveSession[] {
+  return parseSourceSessionList(specToSource(spec), limit, [], opts.includeArchived ?? false, opts.preCollected);
 }
 
-function scanResolvedSource(source: LiveTraceSource, limit: number, includeArchived = false, preCollected?: CollectedSourceFiles): LiveAggregate {
+function scanResolvedSource(source: LiveTraceSource, limit: number, includeArchived = false, preCollected?: CollectedSourceFiles, sessionRetention?: number): LiveAggregate {
   const scanWarnings: string[] = [];
   if (source.status !== "available" && source.message) scanWarnings.push(source.message);
   const sessions = parseSourceSessionList(source, limit, scanWarnings, includeArchived, preCollected);
-  return aggregate(sessions, scanWarnings, source);
+  return aggregate(sessions, scanWarnings, source, sessionRetention);
 }
 
 function collectLiveTraceFiles(source: LiveTraceSource, scanWarnings: string[]): Array<{ file: string; project: string; mtime: number; size: number }> {
@@ -2377,7 +2382,15 @@ function emptyUsageSummary(): LiveUsageSummary {
   };
 }
 
-function aggregate(sessions: LiveSession[], scanWarnings: string[] = [], source: LiveTraceSource = resolveLiveSource()): LiveAggregate {
+/**
+ * Sessions retained on the aggregate's `sessions` field by default. The /live
+ * payload size depends on this cap; callers that need more (Collection's
+ * full-history browse) pass an explicit `sessionRetention`. All `total*`
+ * scalars are computed over EVERY session regardless of retention.
+ */
+const DEFAULT_SESSION_RETENTION = 100;
+
+function aggregate(sessions: LiveSession[], scanWarnings: string[] = [], source: LiveTraceSource = resolveLiveSource(), sessionRetention: number = DEFAULT_SESSION_RETENTION): LiveAggregate {
   const byModelMap = new Map<string, {
     model: string;
     sessions: number;
@@ -2601,6 +2614,6 @@ function aggregate(sessions: LiveSession[], scanWarnings: string[] = [], source:
     agentSessions,
     topBranches: topEntries(branchSessions, 8).map(({ key, count }) => ({ branch: key, sessions: count })),
     topFiles: topEntries(fileSessions, 10).map(({ key, count }) => ({ file: key, sessions: count })),
-    sessions: sessions.slice(0, 100),
+    sessions: sessions.slice(0, sessionRetention),
   };
 }

--- a/tests/collection.test.ts
+++ b/tests/collection.test.ts
@@ -466,6 +466,53 @@ test("fingerprintDiscovery tracks file path, mtime, and size", () => {
   assert.notEqual(fingerprintDiscovery([clone((d) => { d.collected!.files.pop(); d.sessionCount = 1; })]), fp);
 });
 
+// ---- limit-aware session retention ----
+
+test("aggregate retains 100 sessions by default and honors sessionRetention above it", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-retention-"));
+  const COUNT = 160;
+  for (let i = 0; i < COUNT; i++) writeSessionFile(dir, `s${String(i).padStart(3, "0")}.jsonl`, `ret-${i}`);
+  const spec = { id: "retention", label: "Retention", roots: [dir], format: "jsonl-dir" as const };
+
+  const capped = scanSourceSessions(spec, 100_000);
+  assert.equal(capped.sessions.length, 100, "default display cap must stay 100 (the /live payload depends on it)");
+  assert.equal(capped.totalSessions, COUNT, "totals must cover every session regardless of the display cap");
+
+  const wide = scanSourceSessions(spec, 100_000, { sessionRetention: 10_000 });
+  assert.equal(wide.sessions.length, COUNT, "sessionRetention above the corpus size must retain every session");
+
+  // total* scalars must be identical in both — the cap is display-only.
+  assert.equal(wide.totalSessions, capped.totalSessions);
+  assert.equal(wide.totalCostUsd, capped.totalCostUsd);
+  assert.equal(wide.totalInputTokens, capped.totalInputTokens);
+  assert.equal(wide.totalOutputTokens, capped.totalOutputTokens);
+  assert.equal(wide.totalToolCalls, capped.totalToolCalls);
+  assert.equal(wide.sessionsWithInferredCost, capped.sessionsWithInferredCost);
+  assert.deepEqual(wide.usageSummary, capped.usageSummary);
+  // staleMs is wall-clock-derived and differs between the two scans — pin it.
+  const normalize = (sessions: typeof capped.sessions) => sessions.map((s) => ({ ...s, staleMs: 0 }));
+  assert.deepEqual(normalize(wide.sessions.slice(0, 100)), normalize(capped.sessions), "retained head must match the default-capped list");
+});
+
+test("scanAllSources serves more than 100 sessions per source when the limit asks for them", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-retention-all-"));
+  const COUNT = 130;
+  for (let i = 0; i < COUNT; i++) writeSessionFile(dir, `s${String(i).padStart(3, "0")}.jsonl`, `retall-${i}`);
+  const def: CollectionSourceDef = { id: "ret-all", label: "Ret All", roots: [dir], format: "jsonl-dir", parseable: true };
+  _setCollectionHooksForTest(memoTestHooks(def, 60_000));
+  try {
+    const big = scanAllSources(2000);
+    assert.equal(big.totalParsedSessions, COUNT);
+    assert.equal(big.sessions.length, COUNT, "a large limit must not plateau at the old per-source cap of 100");
+
+    const small = scanAllSources(50);
+    assert.equal(small.sessions.length, 50, "the per-call limit still slices the memoized list down");
+    assert.equal(small.totalParsedSessions, COUNT);
+  } finally {
+    _setCollectionHooksForTest(null);
+  }
+});
+
 test("archived sessions are repriced from tokens instead of preserving stale cached estimates", () => {
   const Database = require("better-sqlite3");
   const { _setCacheDbForTest } = require("../lib/live-cache");


### PR DESCRIPTION
## What

- **Limit-aware retention**: `aggregate()` hard-capped its `sessions` field at the newest 100 per source, so Collection's load-more plateaued at ~100 × N_sources (~400 of ~1,282) even though `/api/collection?limit=` accepts up to 10,000. An optional `sessionRetention` now threads from `computeAllSources` (which passes `SESSION_ITEM_CAP` = 10,000) through `scanSourceSessions` → `scanResolvedSource` → `aggregate`. The default stays 100 for `/live` and every caller that doesn't opt in.
- **Snapshot walk reuse**: `computeSnapshot`'s full-history `collectSourceSessions` pass re-walked every source tree that discovery had just walked. It now reuses discovery's `preCollected` file list, eliminating the second directory walk per source per snapshot recompute.

## Contract preserved

`total*` scalars, `usageSummary`, `byModel`/`byTool`, and `sessionsWithInferredCost` were already computed over the full session list before the display slice — `computeAllSources` keeps reading totals from scalars, never from the capped `sessions` array.

## Measured

- E2E (real ~1,276-session corpus, dev server): `/api/collection?limit=2000` → **1,276 of 1,276** sessions (was ~400 plateau); `limit=80` → 80; `/api/live?limit=200` → ≤100 sessions, payload shape unchanged.
- Walk reuse: snapshot collect pass **80.8ms → 30.4ms** (warm parse cache, 5 sources, identical 1,276 sessions out).
- `scripts/perf/equiv-scan.ts` hashes **byte-identical** to HEAD across all 8 configs. PARSER_VERSION untouched.

## Tests

Two regression tests in `tests/collection.test.ts`: default cap pinned at 100 with totals covering all sessions and identical scalars between capped/wide scans; `scanAllSources(2000)` returning >100 per source while `scanAllSources(50)` still slices. `tsc --noEmit`, lint (zero-warning), and full `npm test` green; `scripts/public-upload-audit.sh` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)