### PR TITLE
perf: cursor-paginated Collection sessions

### DIFF
--- a/app/api/collection/route.ts
+++ b/app/api/collection/route.ts
@@ -1,19 +1,51 @@
 import { NextResponse } from "next/server";
-import { scanAllSources } from "@/lib/collection/aggregate";
+import { scanAllSources, type CollectionSessionItem } from "@/lib/collection/aggregate";
 import { discoverAll } from "@/lib/collection/discover";
 
 export const dynamic = "force-dynamic";
 
+/** The snapshot's own session cap — cursor paging walks this whole window. */
+const SNAPSHOT_LIMIT = 10_000;
+const PAGE_DEFAULT = 160;
+const PAGE_MAX = 500;
+
+/** Decoded cursor: position (lastEventAt) + identity (path when present, else sessionId). */
+interface CursorPayload {
+  t: number;
+  id: string;
+  p?: string;
+}
+
+function encodeCursor(s: CollectionSessionItem): string {
+  const payload: CursorPayload = { t: s.lastEventAt, id: s.sessionId };
+  if (s.path) payload.p = s.path;
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(raw: string): CursorPayload | null {
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { t, id, p } = parsed as Record<string, unknown>;
+    if (typeof t !== "number" || !Number.isFinite(t)) return null;
+    if (typeof id !== "string" || id.length === 0) return null;
+    if (p !== undefined && typeof p !== "string") return null;
+    return p === undefined ? { t, id } : { t, id, p };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Machine-wide transcript collection across every known harness.
- *   /api/collection            → full aggregate (discovery + parsed sessions)
- *   /api/collection?mode=discover → cheap discovery report (no session parsing)
+ *   /api/collection                  → full aggregate (discovery + parsed sessions)
+ *   /api/collection?mode=discover    → cheap discovery report (no session parsing)
+ *   /api/collection?cursor=…&page=n  → next page of sessions only (no stats/rollups),
+ *                                      so paging cost stays O(page) on the wire
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const mode = searchParams.get("mode");
-  const parsedLimit = Number(searchParams.get("limit") || 200);
-  const limit = Number.isFinite(parsedLimit) ? Math.max(1, Math.min(10_000, parsedLimit)) : 200;
 
   if (mode === "discover") {
     const report = discoverAll();
@@ -23,11 +55,49 @@ export async function GET(request: Request) {
     );
   }
 
+  const rawCursor = searchParams.get("cursor");
+  if (rawCursor !== null) {
+    const cursor = decodeCursor(rawCursor);
+    if (!cursor) {
+      return NextResponse.json({ error: "malformed cursor" }, { status: 400 });
+    }
+    const parsedPage = Number(searchParams.get("page") || PAGE_DEFAULT);
+    const page = Number.isFinite(parsedPage) ? Math.max(1, Math.min(PAGE_MAX, Math.trunc(parsedPage))) : PAGE_DEFAULT;
+    const data = scanAllSources(SNAPSHOT_LIMIT, { fresh: true });
+    const key = cursor.p ?? cursor.id;
+    const at = data.sessions.findIndex((s) => (s.path ?? s.sessionId) === key);
+    // Vanished cursor (corpus changed between pages): resume at the first item
+    // strictly older than the cursor's timestamp — the client dedupes overlap.
+    const start = at >= 0 ? at + 1 : data.sessions.findIndex((s) => s.lastEventAt < cursor.t);
+    const sessions = start < 0 ? [] : data.sessions.slice(start, start + page);
+    const exhausted = sessions.length === 0 || start + sessions.length >= data.sessions.length;
+    return NextResponse.json(
+      {
+        sessions,
+        nextCursor: exhausted ? null : encodeCursor(sessions[sessions.length - 1]),
+        totalParsedSessions: data.totalParsedSessions,
+        generatedAtMs: data.generatedAtMs,
+      },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+
+  const parsedLimit = Number(searchParams.get("limit") || 200);
+  const limit = Number.isFinite(parsedLimit) ? Math.max(1, Math.min(SNAPSHOT_LIMIT, parsedLimit)) : 200;
+
   // fresh = revalidate the corpus fingerprint NOW (skip the anti-stat-storm
-  // window); it re-parses only if the fingerprint actually changed.
-  const data = scanAllSources(limit, { fresh: true });
+  // window); it re-parses only if the fingerprint actually changed. Fetch the
+  // full snapshot window so the response can carry a continuation cursor.
+  const full = scanAllSources(SNAPSHOT_LIMIT, { fresh: true });
+  const sessions = full.sessions.slice(0, limit);
   return NextResponse.json(
-    data,
+    {
+      ...full,
+      sessions,
+      nextCursor: sessions.length > 0 && sessions.length < full.sessions.length
+        ? encodeCursor(sessions[sessions.length - 1])
+        : null,
+    },
     { headers: { "Cache-Control": "private, no-store" } },
   );
 }

--- a/components/CollectionClient.tsx
+++ b/components/CollectionClient.tsx
@@ -159,6 +159,17 @@ type SessionSort = "recent" | "tokens" | "duration" | "tools";
 const LOAD_STEP = 160;
 const MAX_LIMIT = 10_000;
 
+/** Full `?limit=` response — `AllSourcesResult` plus its continuation cursor. */
+type CollectionPayload = AllSourcesResult & { nextCursor?: string | null };
+
+/** Sessions-only `?cursor=` page — no stats/rollups, so paging stays O(page). */
+interface CursorPage {
+  sessions: AllSourcesResult["sessions"];
+  nextCursor: string | null;
+  totalParsedSessions: number;
+  generatedAtMs: number;
+}
+
 /**
  * Self-ticking relative label, isolated so the 30s tick re-renders only this
  * span — not the whole (potentially 10k-row) page. Starts at the payload's own
@@ -192,10 +203,11 @@ export default function CollectionClient({ initialData, error, initialQuery, rol
   const [sessionSort, setSessionSort] = useState<SessionSort>("recent");
   const [harnessFilter, setHarnessFilter] = useState("all");
   const [modelFilter, setModelFilter] = useState("all");
-  // The scanner keeps only the newest ~100 sessions per source, so a higher
-  // limit may return nothing new even while totalParsedSessions is larger.
-  // Once a load-more round adds no rows, stop offering it.
-  const [listExhausted, setListExhausted] = useState(false);
+  // Exhaustion is cursor-driven: the API returns nextCursor=null once the
+  // listable window (snapshot cap, retention) is walked, even while
+  // totalParsedSessions is larger. `undefined` = no cursor yet (server-rendered
+  // initial data) — the first load-more bootstraps one via a full ?limit= fetch.
+  const [nextCursor, setNextCursor] = useState<string | null | undefined>(undefined);
   const ranInitial = useRef(false);
 
   // A ?q= handoff (e.g. from the dashboard search box) runs immediately.
@@ -261,13 +273,14 @@ export default function CollectionClient({ initialData, error, initialQuery, rol
     }
   }
 
-  async function fetchCollection(limit: number, busy: (v: boolean) => void): Promise<AllSourcesResult | null> {
+  async function fetchCollection(limit: number, busy: (v: boolean) => void): Promise<CollectionPayload | null> {
     busy(true);
     try {
       const res = await fetch(`/api/collection?limit=${Math.min(MAX_LIMIT, Math.max(1, limit))}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const next = (await res.json()) as AllSourcesResult;
+      const next = (await res.json()) as CollectionPayload;
       setData(next);
+      setNextCursor(next.nextCursor ?? null);
       setErr(undefined);
       return next;
     } catch (e) {
@@ -278,16 +291,39 @@ export default function CollectionClient({ initialData, error, initialQuery, rol
     }
   }
 
-  // Rescan keeps however many rows are already loaded instead of snapping back to 80.
+  // Rescan keeps however many rows are already loaded instead of snapping back
+  // to 80; the full-replace response also resets the continuation cursor.
   async function refresh() {
-    const next = await fetchCollection(Math.max(80, data.sessions.length), setLoading);
-    if (next && next.sessions.length > data.sessions.length) setListExhausted(false);
+    await fetchCollection(Math.max(80, data.sessions.length), setLoading);
   }
 
   async function loadMore() {
-    const prevLen = data.sessions.length;
-    const next = await fetchCollection(prevLen + LOAD_STEP, setLoadingMore);
-    if (next) setListExhausted(next.sessions.length <= prevLen);
+    if (loading || loadingMore || nextCursor === null) return;
+    // No cursor yet (initial data came from the server render): one full
+    // ?limit= fetch replaces the list and yields a cursor for later pages.
+    if (nextCursor === undefined) {
+      await fetchCollection(data.sessions.length + LOAD_STEP, setLoadingMore);
+      return;
+    }
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/collection?cursor=${encodeURIComponent(nextCursor)}&page=${LOAD_STEP}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const page = (await res.json()) as CursorPage;
+      setData((prev) => {
+        // The vanished-cursor fallback can overlap already-loaded rows — dedupe
+        // on the same identity the row keys use.
+        const seen = new Set(prev.sessions.map((s) => s.path ?? s.sessionId));
+        const added = page.sessions.filter((s) => !seen.has(s.path ?? s.sessionId));
+        return { ...prev, sessions: [...prev.sessions, ...added], totalParsedSessions: page.totalParsedSessions };
+      });
+      setNextCursor(page.nextCursor);
+      setErr(undefined);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoadingMore(false);
+    }
   }
 
   const models = data.byModel ?? [];
@@ -327,7 +363,8 @@ export default function CollectionClient({ initialData, error, initialQuery, rol
   }, [data.sessions, harnessFilter, modelFilter, sessionSort]);
 
   const sessionsFiltered = harnessFilter !== "all" || modelFilter !== "all";
-  const moreAvailable = !listExhausted && data.sessions.length < data.totalParsedSessions;
+  // undefined (no cursor yet) still offers Load more — only an explicit null is exhausted.
+  const moreAvailable = nextCursor !== null && data.sessions.length < data.totalParsedSessions;
   const loadedLabel = `${fmtNumFull(data.sessions.length)} of ${fmtNumFull(data.totalParsedSessions)} loaded`;
   const hm = rollup?.heatmap ?? [];
   const hasHeatmap = hm.some((row) => row.some((v) => v > 0));

--- a/tests/collection-route.test.ts
+++ b/tests/collection-route.test.ts
@@ -1,0 +1,175 @@
+import test, { after, before } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { defToSpec, type CollectionSourceDef } from "../lib/collection/sources";
+import type { DiscoveredSource } from "../lib/collection/discover";
+import { _setCacheDbForTest } from "../lib/live-cache";
+import { collectSourceFiles } from "../lib/live";
+import { _setCollectionHooksForTest, type CollectionSessionItem } from "../lib/collection/aggregate";
+
+// Every scan goes through the live-cache; an in-memory DB keeps parallel test
+// processes off the shared .test-data SQLite cache.
+const cacheDb = new Database(":memory:");
+_setCacheDbForTest(cacheDb);
+
+const corpusDir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-collection-route-"));
+const sourceDef: CollectionSourceDef = { id: "route-src", label: "Route Src", roots: [corpusDir], format: "jsonl-dir", parseable: true };
+
+/** Hooks that mirror discoverKnownSources for one temp-dir source. */
+function routeTestHooks(def: CollectionSourceDef) {
+  const discover = (): DiscoveredSource[] => {
+    const collected = collectSourceFiles(defToSpec(def));
+    let lastActivityMs: number | null = null;
+    for (const f of collected.files) {
+      if (lastActivityMs == null || f.mtime > lastActivityMs) lastActivityMs = f.mtime;
+    }
+    return [{
+      id: def.id, label: def.label, format: def.format, parseable: def.parseable,
+      roots: def.roots, presentRoots: def.roots,
+      sessionCount: collected.files.length, lastActivityMs,
+      status: collected.files.length > 0 ? "present" : "empty",
+      collected,
+    }];
+  };
+  return { discover, sources: () => [def], unknown: () => [], fingerprintTtlMs: 60_000 };
+}
+
+function writeSessionFile(sessionId: string, iso: string): void {
+  const file = path.join(corpusDir, `${sessionId}.jsonl`);
+  fs.writeFileSync(
+    file,
+    [
+      { type: "system", sessionId, cwd: "/tmp/proj", timestamp: iso },
+      { type: "assistant", timestamp: iso, message: { content: [{ type: "text", text: `done ${sessionId}` }] } },
+      { type: "result", timestamp: iso, duration_ms: 1000, num_turns: 1, usage: { input_tokens: 10, output_tokens: 5 } },
+    ].map((l) => JSON.stringify(l)).join("\n"),
+    "utf8",
+  );
+  // lastEventAt is max(file mtime, latest event ts) — backdate the mtime to the
+  // event time (as real transcripts have) so lastEventAt is deterministic.
+  fs.utimesSync(file, new Date(iso), new Date(iso));
+}
+
+// Newest-first order after the sort is s7, s6, …, s1.
+const ALL_IDS = ["s7", "s6", "s5", "s4", "s3", "s2", "s1"];
+before(() => {
+  for (let i = 1; i <= 7; i++) {
+    writeSessionFile(`s${i}`, `2026-06-2${i}T12:00:00.000Z`);
+  }
+  _setCollectionHooksForTest(routeTestHooks(sourceDef));
+});
+
+after(() => {
+  _setCollectionHooksForTest(null);
+  _setCacheDbForTest(null);
+  cacheDb.close();
+  fs.rmSync(corpusDir, { recursive: true, force: true });
+});
+
+// Route import is dynamic so hooks and the temp corpus exist before any scan.
+async function getCollection(query: string): Promise<Response> {
+  const route = await import("../app/api/collection/route");
+  return route.GET(new Request(`http://localhost:3000/api/collection${query}`));
+}
+
+function identity(s: CollectionSessionItem): string {
+  return s.path ?? s.sessionId;
+}
+
+test("?limit= response keeps its full-aggregate shape and gains nextCursor", async () => {
+  const res = await getCollection("?limit=3");
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  // Existing consumers' fields are all still present.
+  assert.ok(Array.isArray(body.sources));
+  assert.ok(Array.isArray(body.byModel));
+  assert.ok(Array.isArray(body.byTool));
+  assert.equal(typeof body.generatedAtMs, "number");
+  assert.equal(body.totalParsedSessions, 7);
+  assert.equal(body.sessions.length, 3);
+  assert.deepEqual(body.sessions.map((s: CollectionSessionItem) => s.sessionId), ["s7", "s6", "s5"]);
+  assert.equal(typeof body.nextCursor, "string", "a truncated list must carry a continuation cursor");
+
+  // A limit that covers the whole corpus is exhausted: nextCursor is null.
+  const all = await (await getCollection("?limit=100")).json();
+  assert.equal(all.sessions.length, 7);
+  assert.equal(all.nextCursor, null);
+});
+
+test("cursor page-walk unions to exactly the corpus with no duplicates", async () => {
+  const first = await (await getCollection("?limit=2")).json();
+  const seen: string[] = first.sessions.map(identity);
+  let cursor: string | null = first.nextCursor;
+  let pages = 0;
+  while (cursor !== null) {
+    assert.ok(pages < 20, "cursor walk must terminate");
+    const res = await getCollection(`?cursor=${encodeURIComponent(cursor)}&page=2`);
+    assert.equal(res.status, 200);
+    const page = await res.json();
+    assert.ok(page.sessions.length <= 2);
+    // Cursor pages are sessions-only — no stats/rollups on the wire.
+    assert.equal(page.sources, undefined);
+    assert.equal(page.byModel, undefined);
+    assert.equal(page.totalParsedSessions, 7);
+    seen.push(...page.sessions.map(identity));
+    cursor = page.nextCursor;
+    pages++;
+  }
+  assert.equal(new Set(seen).size, seen.length, "no duplicates across pages");
+  assert.deepEqual(
+    seen.map((p) => path.basename(p, ".jsonl")),
+    ALL_IDS,
+    "union of all pages is the whole corpus, newest first",
+  );
+});
+
+test("the same cursor over an unchanged snapshot returns an identical page", async () => {
+  const first = await (await getCollection("?limit=3")).json();
+  const a = await (await getCollection(`?cursor=${encodeURIComponent(first.nextCursor)}&page=3`)).json();
+  const b = await (await getCollection(`?cursor=${encodeURIComponent(first.nextCursor)}&page=3`)).json();
+  assert.deepEqual(a.sessions.map(identity), b.sessions.map(identity));
+  assert.equal(a.nextCursor, b.nextCursor);
+  assert.deepEqual(a.sessions.map((s: CollectionSessionItem) => s.sessionId), ["s4", "s3", "s2"]);
+});
+
+test("a vanished cursor falls back to the first strictly-older item", async () => {
+  // Cursor identity that no longer exists, positioned at s5's timestamp:
+  // the walk must resume at the first item with lastEventAt < t (s4).
+  const t = Date.parse("2026-06-25T12:00:00.000Z");
+  const ghost = Buffer.from(JSON.stringify({ t, id: "no-such-session" }), "utf8").toString("base64url");
+  const res = await getCollection(`?cursor=${encodeURIComponent(ghost)}&page=2`);
+  assert.equal(res.status, 200);
+  const page = await res.json();
+  assert.deepEqual(page.sessions.map((s: CollectionSessionItem) => s.sessionId), ["s4", "s3"]);
+  assert.equal(typeof page.nextCursor, "string");
+
+  // Older than everything → empty page, exhausted.
+  const past = Buffer.from(JSON.stringify({ t: 0, id: "no-such-session" }), "utf8").toString("base64url");
+  const empty = await (await getCollection(`?cursor=${encodeURIComponent(past)}&page=2`)).json();
+  assert.deepEqual(empty.sessions, []);
+  assert.equal(empty.nextCursor, null);
+});
+
+test("malformed cursors are a 400 with a JSON error", async () => {
+  for (const bad of ["garbage!!", "", Buffer.from("{\"nope\":1}").toString("base64url"), Buffer.from("[1,2]").toString("base64url")]) {
+    const res = await getCollection(`?cursor=${encodeURIComponent(bad)}&page=2`);
+    assert.equal(res.status, 400, `cursor ${JSON.stringify(bad)} must be rejected`);
+    const body = await res.json();
+    assert.equal(typeof body.error, "string");
+  }
+});
+
+test("page size is clamped to 1..500 and defaults on junk", async () => {
+  const first = await (await getCollection("?limit=1")).json();
+  const cursor = encodeURIComponent(first.nextCursor);
+  const clampedLow = await (await getCollection(`?cursor=${cursor}&page=0`)).json();
+  assert.equal(clampedLow.sessions.length, 1);
+  const clampedJunk = await (await getCollection(`?cursor=${cursor}&page=nope`)).json();
+  assert.equal(clampedJunk.sessions.length, 6, "junk page falls back to the default and returns the rest");
+  const clampedHigh = await (await getCollection(`?cursor=${cursor}&page=9999`)).json();
+  assert.equal(clampedHigh.sessions.length, 6);
+  assert.equal(clampedHigh.nextCursor, null);
+});


### PR DESCRIPTION
## What

Replaces the Collection page's ever-growing `?limit=` load-more with cursor pagination, so each page costs O(page) on the wire instead of re-shipping everything already loaded.

### API (`app/api/collection/route.ts`)
- New `?cursor=<opaque>&page=<n>` mode (page clamped 1..500, default 160): returns `{ sessions, nextCursor, totalParsedSessions, generatedAtMs }` only — no stats/rollups/byModel payload.
- Cursor is an opaque base64url of `{ lastEventAt, sessionId, path? }`; identity is `path ?? sessionId`.
- Vanished cursor (corpus changed between pages) resumes at the first item strictly older than the cursor's timestamp; the client dedupes any overlap.
- Malformed cursor → `400 { "error": "malformed cursor" }`.
- `?limit=` responses keep their exact shape and gain an additive `nextCursor` (cursor of the last returned session, or `null` when exhausted).

### Client (`components/CollectionClient.tsx`)
- `loadMore()` fetches cursor pages and **appends** (dedupe on `path ?? sessionId`); exhaustion is `nextCursor === null` (replaces the old length-comparison heuristic).
- Initial server-rendered data has no cursor: the first load-more bootstraps one via a single full `?limit=` fetch, then pages via cursor.
- Rescan keeps full-replace semantics and resets the cursor from the response. Sort/filter, row keys, footer text, and error banner unchanged.

### Tests (`tests/collection-route.test.ts`)
Route-level coverage via a temp corpus + collection hooks: full page-walk unions to exactly the corpus with no duplicates; cursor stability across identical snapshots; vanished-cursor fallback; malformed cursor → 400; `?limit=` shape unchanged + `nextCursor`; page clamping.

## Verification

- `npx tsc --noEmit`, `npm run lint` (zero warnings), full `npm test` — all green.
- E2E against the real ~1.3k-session corpus on `:3111`: cursor walk unions to **1,276 = totalParsedSessions** with **0 duplicates**; per-page payload 73–129 KB vs **892 KB** for the old `?limit=1276` payload (a page is ≤14.4% of the old full response).
- `bash scripts/public-upload-audit.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)