### PR TITLE
fix: detect same-size mtime-preserving transcript rewrites (content sentinel + cache bypass)

### DIFF
--- a/lib/collection/aggregate.ts
+++ b/lib/collection/aggregate.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
 import { collectSourceSessions, scanSourceSessions, type LiveAggregate, type LiveSession } from "../live";
 import { allCollectionSources, defToSpec, type CollectionSourceDef } from "./sources";
 import { discoverKnownSources, discoverUnknownCandidates, type DiscoveredSource, type UnknownCandidate } from "./discover";
@@ -194,7 +195,7 @@ const FULL_HISTORY = 100_000;
 /** Sessions retained in the memoized result; per-call `limit` slices down from this. */
 const SESSION_ITEM_CAP = 10_000;
 
-function computeAllSources(discovered: DiscoveredSource[], byId: Map<string, DiscoveredSource>): AllSourcesResult {
+function computeAllSources(discovered: DiscoveredSource[], byId: Map<string, DiscoveredSource>, reparseFiles?: ReadonlySet<string>): AllSourcesResult {
   const summaries: CollectedSourceSummary[] = [];
   const allSessions: CollectionSessionItem[] = [];
   const modelLists: ModelRollup[][] = [];
@@ -234,7 +235,7 @@ function computeAllSources(discovered: DiscoveredSource[], byId: Map<string, Dis
       // whole source tree for the scan.
       // Retain up to SESSION_ITEM_CAP per source (not the default 100) so the
       // memoized cross-source list can satisfy large ?limit= requests.
-      const agg: LiveAggregate = scanSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: disc?.collected, sessionRetention: SESSION_ITEM_CAP });
+      const agg: LiveAggregate = scanSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: disc?.collected, sessionRetention: SESSION_ITEM_CAP, reparseFiles });
       base.archivedSessions = agg.archivedSessions;
       base.parsedSessions = agg.totalSessions;
       base.totalCostUsd = agg.totalCostUsd;
@@ -346,6 +347,7 @@ export function _setCollectionHooksForTest(overrides: Partial<CollectionHooks> |
   hooks = overrides ? { ...DEFAULT_HOOKS, ...overrides } : DEFAULT_HOOKS;
   snapshot = null;
   lastValidatedAt = 0;
+  sentinelCache.clear();
 }
 
 /**
@@ -367,6 +369,85 @@ export function fingerprintDiscovery(discovered: DiscoveredSource[]): string {
 }
 
 /**
+ * Content sentinel: sha256 of the first + last 4KB of a file (the whole file
+ * when it fits in one 8KB span), read via positioned `readSync` so a
+ * multi-hundred-MB transcript costs two small reads. The stat fingerprint
+ * above is blind to a rewrite that lands on the same (mtime, size) tuple —
+ * `utimesSync`-restoring writers, editors that preserve timestamps, coarse
+ * mtime clocks — and BOTH parse-cache tiers key on that same tuple, so such a
+ * rewrite would otherwise serve a stale parse forever.
+ *
+ * Known limits (accepted): the baseline is in-process, so a same-tuple rewrite
+ * that happens while the server is down baselines as a first sighting on
+ * restart (the persistent cache row stays stale); and an edit confined to the
+ * interior of a >8KB file with head+tail bytes unchanged is invisible.
+ */
+const SENTINEL_SPAN = 4096;
+
+interface SentinelEntry { mtime: number; size: number; sentinel: string }
+
+const sentinelCache = new Map<string, SentinelEntry>();
+
+function readSentinel(file: string, size: number): string | null {
+  let fd: number;
+  try {
+    fd = fs.openSync(file, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const h = crypto.createHash("sha256");
+    if (size <= SENTINEL_SPAN * 2) {
+      const buf = Buffer.allocUnsafe(size);
+      const n = fs.readSync(fd, buf, 0, size, 0);
+      h.update(buf.subarray(0, n));
+    } else {
+      const buf = Buffer.allocUnsafe(SENTINEL_SPAN);
+      const head = fs.readSync(fd, buf, 0, SENTINEL_SPAN, 0);
+      h.update(buf.subarray(0, head));
+      const tail = fs.readSync(fd, buf, 0, SENTINEL_SPAN, size - SENTINEL_SPAN);
+      h.update(buf.subarray(0, tail));
+    }
+    return h.digest("hex");
+  } catch {
+    return null;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Re-read every discovered file's sentinel and refresh the cache. Returns the
+ * files whose content changed under an UNCHANGED (mtime, size) tuple — the
+ * rewrites the stat fingerprint cannot see. First sightings (and files whose
+ * stat changed, which the fingerprint already catches) just record a baseline.
+ * A vanished/unreadable file drops its entry; the next stat pass owns that.
+ */
+function sentinelDirtyFiles(discovered: DiscoveredSource[]): Set<string> {
+  const dirty = new Set<string>();
+  const seen = new Set<string>();
+  for (const d of discovered) {
+    if (!d.collected) continue;
+    for (const f of d.collected.files) {
+      seen.add(f.file);
+      const sentinel = readSentinel(f.file, f.size);
+      if (sentinel == null) {
+        sentinelCache.delete(f.file);
+        continue;
+      }
+      const prev = sentinelCache.get(f.file);
+      if (prev && prev.mtime === f.mtime && prev.size === f.size && prev.sentinel !== sentinel) dirty.add(f.file);
+      sentinelCache.set(f.file, { mtime: f.mtime, size: f.size, sentinel });
+    }
+  }
+  // Prune entries for files no longer on disk so the map tracks the corpus.
+  for (const file of sentinelCache.keys()) {
+    if (!seen.has(file)) sentinelCache.delete(file);
+  }
+  return dirty;
+}
+
+/**
  * Full discovery + parse is 0.4–2s+ and runs synchronously inside server-
  * component renders — and one render used to run it up to three times
  * (sources scan, rollup, timeline). Instead of a blind 5s TTL, the memo is
@@ -383,20 +464,30 @@ function getSnapshot(opts: { fresh?: boolean } = {}): CollectionSnapshot {
   if (!opts.fresh && snapshot && now - lastValidatedAt < ttlMs) return snapshot;
   const discovered = hooks.discover();
   const fingerprint = fingerprintDiscovery(discovered);
-  if (!snapshot || snapshot.fingerprint !== fingerprint) {
-    snapshot = computeSnapshot(discovered, fingerprint);
+  const prev = snapshot;
+  const statChanged = !prev || prev.fingerprint !== fingerprint;
+  // Sentinel pass: on `fresh` revalidation (and alongside any recompute, whose
+  // parse cost dwarfs it) re-read each file's head/tail hash to catch rewrites
+  // the stat tuple missed, and to keep the baseline aligned with what the
+  // parse below reads. The TTL path with an unchanged fingerprint — the warm
+  // page-render case — stays stat-only.
+  const dirty = statChanged || opts.fresh ? sentinelDirtyFiles(discovered) : new Set<string>();
+  if (!prev || statChanged || dirty.size > 0) {
+    snapshot = computeSnapshot(discovered, fingerprint, dirty);
   } else if (opts.fresh) {
     // Explicit rescan with an unchanged corpus: the parse memo stands, but the
     // unknown-candidate walk covers dirs OUTSIDE the fingerprint — re-run it so
     // a newly installed agent CLI still surfaces without a known-source change.
     const unknown = hooks.unknown(discovered.flatMap((d) => d.roots));
-    snapshot = { ...snapshot, result: { ...snapshot.result, unknown } };
+    snapshot = { ...prev, result: { ...prev.result, unknown } };
+  } else {
+    snapshot = prev;
   }
   lastValidatedAt = now;
   return snapshot;
 }
 
-function computeSnapshot(discovered: DiscoveredSource[], fingerprint: string): CollectionSnapshot {
+function computeSnapshot(discovered: DiscoveredSource[], fingerprint: string, reparseFiles?: ReadonlySet<string>): CollectionSnapshot {
   // Aggregate first: scanSourceSessions primes the per-file session cache, so
   // the full-history collection below re-reads no transcript bytes. The
   // collection deliberately covers every parseable def — not just "present"
@@ -404,13 +495,16 @@ function computeSnapshot(discovered: DiscoveredSource[], fingerprint: string): C
   // the parse cache and must keep feeding rollup/timeline (as they did when
   // those callers collected for themselves).
   const byId = new Map(discovered.map((d) => [d.id, d]));
-  const result = computeAllSources(discovered, byId);
+  const result = computeAllSources(discovered, byId, reparseFiles);
   const sessions: CollectedSession[] = [];
   for (const def of hooks.sources()) {
     if (!def.parseable) continue;
     // Reuse discovery's walk here too — without it, every snapshot recompute
     // walked each source tree a second time just to re-list the same files.
-    for (const s of collectSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: byId.get(def.id)?.collected })) {
+    // reparseFiles is threaded here as well: the scan above normally overwrites
+    // the stale cache rows first, but this collection must not depend on that
+    // ordering to avoid re-serving a stale parse.
+    for (const s of collectSourceSessions(defToSpec(def), FULL_HISTORY, { includeArchived: true, preCollected: byId.get(def.id)?.collected, reparseFiles })) {
       sessions.push({ ...s, sourceId: def.id, sourceLabel: def.label });
     }
   }

--- a/lib/live.ts
+++ b/lib/live.ts
@@ -316,9 +316,12 @@ export function collectSourceFiles(spec: CollectionSourceSpec): CollectedSourceF
  * Scan one arbitrary collection source (any harness), reusing the harness path.
  * `sessionRetention` widens the aggregate's display-capped `sessions` field
  * (default 100) for callers that browse full history; totals are unaffected.
+ * `reparseFiles` lists files whose CONTENT changed under an unchanged
+ * (mtime, size) stat tuple — both parse-cache tiers key on that tuple, so a
+ * listed file must skip them, re-parse, and overwrite the stale cached row.
  */
-export function scanSourceSessions(spec: CollectionSourceSpec, limit = 200, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles; sessionRetention?: number } = {}): LiveAggregate {
-  return scanResolvedSource(specToSource(spec), limit, opts.includeArchived ?? false, opts.preCollected, opts.sessionRetention);
+export function scanSourceSessions(spec: CollectionSourceSpec, limit = 200, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles; sessionRetention?: number; reparseFiles?: ReadonlySet<string> } = {}): LiveAggregate {
+  return scanResolvedSource(specToSource(spec), limit, opts.includeArchived ?? false, opts.preCollected, opts.sessionRetention, opts.reparseFiles);
 }
 
 export function defaultLiveLimitForHarness(harness?: string): number {
@@ -719,7 +722,7 @@ export function scanLiveSessions(limit = 200, harness?: string): LiveAggregate {
   return scanResolvedSource(resolveLiveSource(harness), limit);
 }
 
-function parseSourceSessionList(source: LiveTraceSource, limit: number, scanWarnings: string[], includeArchived = false, preCollected?: CollectedSourceFiles): LiveSession[] {
+function parseSourceSessionList(source: LiveTraceSource, limit: number, scanWarnings: string[], includeArchived = false, preCollected?: CollectedSourceFiles, reparseFiles?: ReadonlySet<string>): LiveSession[] {
   const sessions: LiveSession[] = [];
   if (source.status !== "available") return sessions;
   let files: Array<{ file: string; project: string; mtime: number; size: number }>;
@@ -735,11 +738,12 @@ function parseSourceSessionList(source: LiveTraceSource, limit: number, scanWarn
     // The walk already stat'd every file; reuse it for the cache key instead
     // of a second statSync per file inside summarizeWithCache.
     const stat = { mtimeMs: f.mtime, size: f.size };
+    const forceReparse = reparseFiles?.has(f.file) ?? false;
     const s = source.format === "codex-sessions"
-      ? summarizeCodexSessionFile(f.file, f.project, f.mtime, stat)
+      ? summarizeCodexSessionFile(f.file, f.project, f.mtime, stat, forceReparse)
       : source.format === "hermes-json"
-        ? summarizeHermesSessionFile(f.file, f.project, f.mtime, stat)
-        : summarizeLiveSessionFile(f.file, f.project, f.mtime, { fields: source.fields, inferredModel: source.inferredModel, decodeProject: source.format !== "jsonl-dir", stat });
+        ? summarizeHermesSessionFile(f.file, f.project, f.mtime, stat, forceReparse)
+        : summarizeLiveSessionFile(f.file, f.project, f.mtime, { fields: source.fields, inferredModel: source.inferredModel, decodeProject: source.format !== "jsonl-dir", stat, forceReparse });
     if (s) {
       // Codex/ChatGPT rotates older rollouts into a dedicated on-disk archive.
       // Those files are still live-readable, but must retain archive provenance
@@ -827,14 +831,14 @@ function appendArchivedSessions(source: LiveTraceSource, sessions: LiveSession[]
  * array is retention-capped for display; longitudinal analytics need them all).
  * Pass `preCollected` (e.g. discovery's walk) to skip re-walking the tree.
  */
-export function collectSourceSessions(spec: CollectionSourceSpec, limit = 100_000, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles } = {}): LiveSession[] {
-  return parseSourceSessionList(specToSource(spec), limit, [], opts.includeArchived ?? false, opts.preCollected);
+export function collectSourceSessions(spec: CollectionSourceSpec, limit = 100_000, opts: { includeArchived?: boolean; preCollected?: CollectedSourceFiles; reparseFiles?: ReadonlySet<string> } = {}): LiveSession[] {
+  return parseSourceSessionList(specToSource(spec), limit, [], opts.includeArchived ?? false, opts.preCollected, opts.reparseFiles);
 }
 
-function scanResolvedSource(source: LiveTraceSource, limit: number, includeArchived = false, preCollected?: CollectedSourceFiles, sessionRetention?: number): LiveAggregate {
+function scanResolvedSource(source: LiveTraceSource, limit: number, includeArchived = false, preCollected?: CollectedSourceFiles, sessionRetention?: number, reparseFiles?: ReadonlySet<string>): LiveAggregate {
   const scanWarnings: string[] = [];
   if (source.status !== "available" && source.message) scanWarnings.push(source.message);
-  const sessions = parseSourceSessionList(source, limit, scanWarnings, includeArchived, preCollected);
+  const sessions = parseSourceSessionList(source, limit, scanWarnings, includeArchived, preCollected, reparseFiles);
   return aggregate(sessions, scanWarnings, source, sessionRetention);
 }
 
@@ -979,14 +983,14 @@ export function getErroringTurns(filePath: string, format?: LiveTraceFormat): Tr
 /** Walk-time stat, reusable as the cache key so summarize needn't re-stat. */
 export interface KnownFileStat { mtimeMs: number; size: number }
 
-export function summarizeLiveSessionFile(file: string, projectDir: string, mtime: number, opts: { fields?: FieldMapping; inferredModel?: string; decodeProject?: boolean; stat?: KnownFileStat } = {}): LiveSession | null {
-  return summarizeWithCache(file, projectDir, mtime, (f, lines, bytes, pd, mt) => parseLiveSession(f, lines, bytes, pd, mt, opts.fields, opts.inferredModel, opts.decodeProject), opts.stat);
+export function summarizeLiveSessionFile(file: string, projectDir: string, mtime: number, opts: { fields?: FieldMapping; inferredModel?: string; decodeProject?: boolean; stat?: KnownFileStat; forceReparse?: boolean } = {}): LiveSession | null {
+  return summarizeWithCache(file, projectDir, mtime, (f, lines, bytes, pd, mt) => parseLiveSession(f, lines, bytes, pd, mt, opts.fields, opts.inferredModel, opts.decodeProject), opts.stat, opts.forceReparse);
 }
 
 const HERMES_MAX_BYTES = 32 * 1024 * 1024; // whole-file JSON parse; real sessions are ≤ a few MB
 
 /** Hermes single-JSON sessions, re-emitted as Claude-style records (see adapters/hermes). */
-export function summarizeHermesSessionFile(file: string, projectDir: string, mtime: number, stat?: KnownFileStat): LiveSession | null {
+export function summarizeHermesSessionFile(file: string, projectDir: string, mtime: number, stat?: KnownFileStat, forceReparse?: boolean): LiveSession | null {
   return summarizeWithCache(file, projectDir, mtime, (f, lines, bytes, pd, mt) => {
     if (bytes > HERMES_MAX_BYTES) return null;
     let raw = "";
@@ -994,7 +998,7 @@ export function summarizeHermesSessionFile(file: string, projectDir: string, mti
     const records = hermesJsonToRecords(raw);
     if (records.length === 0) return null;
     return parseLiveSession(f, records, bytes, pd, mt, undefined, undefined, false);
-  }, stat);
+  }, stat, forceReparse);
 }
 
 const sessionCache = new Map<string, { mtimeMs: number; size: number; session: LiveSession | null }>();
@@ -1046,6 +1050,7 @@ function summarizeWithCache(
   mtime: number,
   parser: (file: string, lines: Iterable<string>, bytes: number, projectDir: string, mtime: number) => LiveSession | null,
   knownStat?: KnownFileStat,
+  forceReparse = false,
 ): LiveSession | null {
   // Callers coming from the directory walk already stat'd the file; their
   // values are the same ones the mtime sort trusted, so reuse them as the
@@ -1065,19 +1070,24 @@ function summarizeWithCache(
   const refresh = (s: LiveSession | null): LiveSession | null =>
     s ? { ...s, staleMs: Math.max(0, Date.now() - s.lastEventAt) } : s;
 
-  const cached = sessionCache.get(file);
-  if (cached && cached.mtimeMs === st.mtimeMs && cached.size === st.size) {
-    // Re-insert on hit: Map iteration is insertion-ordered, so this turns the
-    // FIFO eviction below into LRU (hits survive a scan that overflows the cap).
-    sessionCache.delete(file);
-    sessionCache.set(file, cached);
-    return refresh(cached.session);
+  // forceReparse: the caller detected a content rewrite under an unchanged
+  // (mtime, size) tuple — both cache tiers key on that tuple, so their rows
+  // are stale. Skip them, parse the file, and overwrite both entries below.
+  if (!forceReparse) {
+    const cached = sessionCache.get(file);
+    if (cached && cached.mtimeMs === st.mtimeMs && cached.size === st.size) {
+      // Re-insert on hit: Map iteration is insertion-ordered, so this turns the
+      // FIFO eviction below into LRU (hits survive a scan that overflows the cap).
+      sessionCache.delete(file);
+      sessionCache.set(file, cached);
+      return refresh(cached.session);
+    }
   }
   // Second tier: the persistent SQLite cache survives restarts, so cold
   // full-history scans don't re-parse hundreds of MB of unchanged files.
-  const persisted = cacheGet(file, st.mtimeMs, st.size);
+  const persisted = forceReparse ? null : cacheGet(file, st.mtimeMs, st.size);
   let session: LiveSession | null;
-  if (persisted.hit) {
+  if (persisted?.hit) {
     session = persisted.session;
   } else {
     try {
@@ -1602,8 +1612,8 @@ function parseLiveSession(file: string, lines: Iterable<string>, bytes: number, 
   };
 }
 
-export function summarizeCodexSessionFile(file: string, projectDir: string, mtime: number, stat?: KnownFileStat): LiveSession | null {
-  return summarizeWithCache(file, projectDir, mtime, parseCodexSession, stat);
+export function summarizeCodexSessionFile(file: string, projectDir: string, mtime: number, stat?: KnownFileStat, forceReparse?: boolean): LiveSession | null {
+  return summarizeWithCache(file, projectDir, mtime, parseCodexSession, stat, forceReparse);
 }
 
 const ORCHESTRATION_MARKERS = /\b(team of agents|coordinator|orchestrat\w*|primary agent|worker \d|subagent|multi-agent)\b/i;

--- a/tests/collection.test.ts
+++ b/tests/collection.test.ts
@@ -466,6 +466,52 @@ test("fingerprintDiscovery tracks file path, mtime, and size", () => {
   assert.notEqual(fingerprintDiscovery([clone((d) => { d.collected!.files.pop(); d.sessionCount = 1; })]), fp);
 });
 
+// ---- content sentinel: same-size mtime-preserving rewrites ----
+
+test("fresh scan re-parses a same-size mtime-preserving rewrite (stat fingerprint blind spot)", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-sentinel-"));
+  const def: CollectionSourceDef = { id: "sentinel", label: "Sentinel", roots: [dir], format: "jsonl-dir", parseable: true };
+  const file = path.join(dir, "a.jsonl");
+  const pin = new Date("2026-06-28T21:00:00.000Z");
+  writeSessionFile(dir, "a.jsonl", "rw-one");
+  fs.utimesSync(file, pin, pin);
+  const sizeBefore = fs.statSync(file).size;
+  _setCollectionHooksForTest(memoTestHooks(def, 60_000));
+  try {
+    const r1 = scanAllSources(50);
+    assert.equal(r1.totalParsedSessions, 1);
+    assert.equal(r1.sessions[0].sessionId, "rw-one");
+
+    // Rewrite with same-length content and restore the mtime: the
+    // (path, mtime, size) fingerprint cannot see this change.
+    writeSessionFile(dir, "a.jsonl", "rw-two");
+    fs.utimesSync(file, pin, pin);
+    assert.equal(fs.statSync(file).size, sizeBefore, "rewrite must keep the byte size identical");
+    assert.equal(fs.statSync(file).mtimeMs, pin.getTime(), "rewrite must keep the mtime identical");
+
+    // Within the TTL window the memo may legitimately serve the old snapshot.
+    assert.equal(scanAllSources(50).sessions[0].sessionId, "rw-one");
+
+    // fresh:true re-reads content sentinels, detects the rewrite, and serves
+    // the RE-PARSED content — both parse-cache tiers key on the unchanged
+    // stat tuple and must be bypassed, not just invalidated.
+    const r2 = scanAllSources(50, { fresh: true });
+    assert.equal(r2.totalParsedSessions, 1);
+    assert.equal(r2.sessions[0].sessionId, "rw-two");
+    assert.equal(collectAllSessions()[0].sessionId, "rw-two");
+
+    // The persistent cache row (same stat key) must now hold the fresh parse.
+    const row = fileCacheDb.prepare("SELECT session_json FROM session_cache WHERE file = ?").get(file) as { session_json: string };
+    assert.equal(JSON.parse(row.session_json).sessionId, "rw-two");
+
+    // Unchanged corpus afterwards: the sentinel pass must not force recomputes.
+    const r3 = scanAllSources(50, { fresh: true });
+    assert.equal(r3.sessions[0], r2.sessions[0], "matching sentinels must keep serving the memoized parse");
+  } finally {
+    _setCollectionHooksForTest(null);
+  }
+});
+
 // ---- limit-aware session retention ----
 
 test("aggregate retains 100 sessions by default and honors sessionRetention above it", () => {


### PR DESCRIPTION
## Problem

Two stacked blind spots let a rewritten transcript serve a stale parse forever:

1. The corpus fingerprint (`fingerprintDiscovery`) keys on per-file `(path, mtime, size)`. A same-size rewrite that preserves mtime (write + `utimesSync` restore, timestamp-preserving editors, coarse mtime clocks) never changes it, so `fresh:true` rescans kept serving the memoized snapshot.
2. Even with detection, both parse-cache tiers (`sessionCache` Map in `lib/live.ts` and the SQLite `session_cache` in `lib/live-cache.ts`) key on the same `(file, mtime, size)` tuple — a recompute would still hit the stale cached parse. Detection without bypass changes nothing.

## Change

- **Sentinel** (`lib/collection/aggregate.ts`): sha256 of the first + last 4KB (whole file when ≤8KB), read via fd + positioned `fs.readSync` — never the whole file. Module-level `Map<file, {mtime, size, sentinel}>`.
- **Policy**: the TTL path stays stat-only (warm page renders unchanged). On `fresh:true` — and alongside any fingerprint-triggered recompute, whose parse cost dwarfs it — the sentinel pass re-reads each file; a hash mismatch under an unchanged stat tuple marks the file dirty. Dirty files force a snapshot recompute with the dirty set threaded through. First sightings just record a baseline.
- **Cache bypass** (`lib/live.ts`): read-path-only `reparseFiles?: ReadonlySet<string>` threaded `scanSourceSessions`/`collectSourceSessions` → `parseSourceSessionList` → `summarize*` → `summarizeWithCache(forceReparse)`, which skips BOTH cache tiers, re-parses, and `cachePut`s the fresh row over the stale one (same key, new content). No `PARSER_VERSION` change. Route-level behavior is unchanged except for correctness.
- **Tests** (`tests/collection.test.ts`): a same-size `utimesSync`-restored rewrite is re-parsed on `fresh:true` (asserted at the content level, including the overwritten SQLite row); the TTL window may legitimately serve the old snapshot; an unchanged corpus keeps same-object memo identity across fresh calls (existing memo tests untouched and passing).

## Measurements (honest numbers)

- Sentinel pass over the operator's real corpus (1,537 parseable files): **~53–56ms** with warm FS cache, **452ms** on the first cold-cache round. This lands on `fresh:true` requests only.
- Warm `/api/collection?limit=80`: **0.256–0.324s after** vs 0.287–0.496s before (3 samples each; load avg 8–10 during both runs — overhead is within noise).
- Response totals identical vs pre-change baseline except live-corpus drift from concurrently active sessions (files/sessions/toolCalls counts identical; tokens/cost moved by an active session appending between samples).
- `scripts/perf/equiv-scan.ts` hashes **identical** before/after (normal-corpus behavior unchanged).
- `tsc --noEmit`, `next lint` (zero warnings), full `npm test` green; `scripts/public-upload-audit.sh` passes.

## Known limits (accepted, documented in the sentinel docstring)

- The sentinel baseline is in-process: a same-tuple rewrite that happens while the server is down baselines as a first sighting on restart, and the persistent cache row stays stale. Closing that would require persisting sentinels in the live-cache schema — out of scope here.
- An edit confined to the interior of a >8KB file with head+tail bytes unchanged is invisible (agent transcripts are append-shaped, so head+tail covers the realistic rewrite cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)