### PR TITLE
fix: add --verbose so claude-code/ncode stream-json runs don't abort

### DIFF
--- a/lib/adapters/builtin.ts
+++ b/lib/adapters/builtin.ts
@@ -13,7 +13,9 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     binEnvVar: "CLAUDE_BIN",
     wellKnownPaths: ["~/.local/bin/claude", "~/.claude/local/claude"],
     parser: "claude-stream-json",
-    argTemplate: ["-p", "--output-format", "stream-json", "--input-format", "text"],
+    // `-p` (--print) with `--output-format stream-json` requires `--verbose`,
+    // otherwise the CLI aborts before producing any output.
+    argTemplate: ["-p", "--output-format", "stream-json", "--input-format", "text", "--verbose"],
     permissionFlag: "--permission-mode",
     workdirFlag: "--add-dir",
     modelFlag: "--model",
@@ -73,7 +75,9 @@ export const BUILTIN_DESCRIPTORS: HarnessDescriptorInput[] = [
     binEnvVar: "NCODE_BIN",
     wellKnownPaths: ["~/.local/bin/ncode", "~/.ncode/bin/ncode"],
     parser: "claude-stream-json",
-    argTemplate: ["-p", "--output-format", "stream-json", "--input-format", "text"],
+    // `-p` (--print) with `--output-format stream-json` requires `--verbose`,
+    // otherwise the CLI aborts before producing any output.
+    argTemplate: ["-p", "--output-format", "stream-json", "--input-format", "text", "--verbose"],
     extraEnv: { NCODE_DISABLE_NONESSENTIAL_TRAFFIC: "1" },
     permissionFlag: "--permission-mode",
     workdirFlag: "--add-dir",

--- a/tests/harness-metadata.test.ts
+++ b/tests/harness-metadata.test.ts
@@ -108,6 +108,33 @@ test("image attachments become repeated descriptor flag pairs", () => {
   ]);
 });
 
+test("claude-code and ncode pass --verbose so stream-json output is not rejected", () => {
+  // The Claude/NCode CLIs abort with
+  // `--print, --output-format=stream-json requires --verbose` unless --verbose
+  // is present. Both the harness-under-test and judge paths build via this
+  // descriptor, so the flag must be baked into the argTemplate.
+  for (const id of ["claude-code", "ncode"]) {
+    const raw = BUILTIN_DESCRIPTORS.find((descriptor) => descriptor.id === id)!;
+    const { descriptor, issues } = validateDescriptor(raw, `test:${id}-verbose-command`);
+    assert.deepEqual(issues, []);
+    const command = buildDescriptorCommand(descriptor!, {
+      caseId: "verbose-case",
+      workdir: "/tmp/workdir",
+      prompt: "solve the task",
+      maxTurns: 5,
+      timeoutMs: 1000,
+      permissionMode: "default",
+      model: "haiku",
+      extraArgs: [],
+      images: [],
+    });
+    assert.ok(command.args.includes("--verbose"), `${id} args must include --verbose`);
+    assert.ok(command.args.includes("-p"), `${id} args must include -p`);
+    assert.ok(command.args.includes("--output-format"), `${id} args must include --output-format`);
+    assert.ok(command.args.includes("stream-json"), `${id} args must include stream-json`);
+  }
+});
+
 test("harness probing verifies version and help without running a model", async () => {
   const version = await runProbe(process.execPath, ["--version"]);
   const help = await runProbe(process.execPath, ["--help"]);


### PR DESCRIPTION
## Problem

Eval runs and `rubric_llm` judge calls against the `claude-code` harness fail immediately with:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

The `claude-code` and `ncode` builtin descriptors build `-p --output-format stream-json --input-format text`. The Claude/NCode CLIs require `--verbose` whenever `--print` is combined with `--output-format stream-json`, so both the harness-under-test path (`lib/runner/spawn.ts`) and the judge path (`lib/grader/judge.ts`) — which share this descriptor builder — abort before producing any output.

## Fix

- Add `--verbose` to the `argTemplate` of both the `claude-code` and `ncode` descriptors in `lib/adapters/builtin.ts` (codex uses a different template and is unaffected).
- Add a regression test in `tests/harness-metadata.test.ts` that builds each command via `buildDescriptorCommand` (same path as the existing codex image test) and asserts the args include `--verbose` while still including `-p`, `--output-format`, and `stream-json`. The test fails without the builtin change.

## Verification

- `npm run typecheck` clean
- `node --import tsx --test tests/harness-metadata.test.ts` — 14 pass
- `npm run selftest` — 26 pass, 0 fail
- Confirmed the new test fails when `builtin.ts` is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)