### PR TITLE
Harden db migrations: narrow migration catch + surface WAL fallback

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -26,7 +26,19 @@ function openDb(): Database.Database {
   const conn = new Database(DB_PATH, { timeout: 15_000 });
   try {
     conn.pragma("busy_timeout = 15000");
+    // WAL sharply lowers SQLITE_BUSY under the parallel-worker writes this DB
+    // sees. On some filesystems (network/overlay mounts) it can't be set and
+    // SQLite silently falls back to rollback-journal mode — read back the
+    // effective mode and warn rather than let the degraded mode pass unnoticed.
     try { conn.pragma("journal_mode = WAL"); } catch {}
+    const journalMode = String(conn.pragma("journal_mode", { simple: true }) ?? "").toLowerCase();
+    if (journalMode !== "wal") {
+      console.warn(
+        `[openeval] eval.db could not enable WAL journal mode (effective mode: ${journalMode || "unknown"}); ` +
+        `expect elevated SQLITE_BUSY contention under parallel runs. ` +
+        `This usually means the database lives on a filesystem that does not support WAL (e.g. a network/overlay mount).`
+      );
+    }
     conn.pragma("synchronous = NORMAL");
     conn.exec(SCHEMA);
     migrate(conn);
@@ -166,17 +178,36 @@ const MIGRATIONS: Array<{ version: number; apply: (conn: Database.Database) => v
 
 export const SCHEMA_VERSION = MIGRATIONS.reduce((max, m) => Math.max(max, m.version), 0);
 
+/**
+ * Run an additive `ADD COLUMN` migration idempotently. We presence-check the
+ * column first, but a concurrent process can add it between the check and the
+ * ALTER — so a "duplicate column name" error is the one benign race we swallow.
+ * Every other failure (disk full, database locked, SQL syntax) means the column
+ * is genuinely absent; swallowing it would let later inserts referencing that
+ * column throw at runtime with no trace of the root cause. Log and rethrow.
+ */
+export function runAddColumn(conn: Database.Database, sql: string): void {
+  try {
+    conn.exec(sql);
+  } catch (e) {
+    const msg = String((e as Error)?.message ?? e);
+    if (msg.includes("duplicate column name")) return;
+    console.error(`[openeval] eval.db migration failed: ${sql} — ${msg}`);
+    throw e;
+  }
+}
+
 function migrate(conn: Database.Database) {
   const runCols = conn.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;
   const runNames = new Set(runCols.map((c) => c.name));
   if (!runNames.has("manifest_json")) {
-    try { conn.exec("ALTER TABLE runs ADD COLUMN manifest_json TEXT"); } catch {}
+    runAddColumn(conn, "ALTER TABLE runs ADD COLUMN manifest_json TEXT");
   }
 
   const cols = conn.prepare("PRAGMA table_info(run_cases)").all() as Array<{ name: string }>;
   const names = new Set(cols.map((c) => c.name));
   const add = (col: string, decl: string) => {
-    if (!names.has(col)) { try { conn.exec(`ALTER TABLE run_cases ADD COLUMN ${col} ${decl}`); } catch {} }
+    if (!names.has(col)) { runAddColumn(conn, `ALTER TABLE run_cases ADD COLUMN ${col} ${decl}`); }
   };
   add("difficulty", "TEXT");
   add("budget_exceeded", "INTEGER DEFAULT 0");

--- a/tests/db-durability.test.ts
+++ b/tests/db-durability.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import Database from "better-sqlite3";
 
 /**
  * Durability tests for lib/db.ts (eval.db):
@@ -207,5 +208,36 @@ test("healthy DB opens without a recovery notice or moved-aside files", () => {
     assert.ok(!names.some((n) => n.includes(".corrupt-")), `no corruption artifacts on a healthy open: ${names}`);
   } finally {
     fs.rmSync(clean, { recursive: true, force: true });
+  }
+});
+
+test("runAddColumn swallows only duplicate-column, rethrows genuine failures", async () => {
+  const dbmod = await importDb();
+  const conn = new Database(":memory:");
+  try {
+    conn.exec("CREATE TABLE t (id INTEGER)");
+
+    // Fresh column: the ALTER runs and the column is added.
+    dbmod.runAddColumn(conn, "ALTER TABLE t ADD COLUMN a TEXT");
+    let cols = (conn.prepare("PRAGMA table_info(t)").all() as Array<{ name: string }>).map((c) => c.name);
+    assert.ok(cols.includes("a"), "column added on first run");
+
+    // Re-running the same ADD COLUMN races into "duplicate column name" — the
+    // one benign case. It must be swallowed so migrate() stays idempotent.
+    assert.doesNotThrow(
+      () => dbmod.runAddColumn(conn, "ALTER TABLE t ADD COLUMN a TEXT"),
+      "duplicate-column ADD must be swallowed (idempotent re-run)"
+    );
+
+    // A genuinely failing migration (here: a missing table) must NOT be
+    // swallowed — the old broad `catch {}` hid disk-full/lock/syntax failures,
+    // then later inserts referencing the absent column threw with no root cause.
+    assert.throws(
+      () => dbmod.runAddColumn(conn, "ALTER TABLE does_not_exist ADD COLUMN x TEXT"),
+      /no such table/,
+      "a non-duplicate migration error must propagate, not be swallowed"
+    );
+  } finally {
+    conn.close();
   }
 });


### PR DESCRIPTION
## Summary

Two stability fixes confined to `lib/db.ts`, hardening the SQLite layer against silent failure modes.

### 1. Migration catch was too broad
The additive `ALTER TABLE ... ADD COLUMN` migrations were wrapped in a blanket `catch {}` that swallowed **every** error. A genuinely failing migration (disk full, database locked, SQL syntax) was silently ignored, then later inserts referencing the missing column threw at runtime with no trace of the root cause.

Now a shared `runAddColumn()` helper swallows only the one benign case — the `duplicate column name` race (a concurrent process adding the column between the presence-check and the ALTER) — and logs + rethrows anything else.

The corruption-recovery path is preserved: real `SQLITE_CORRUPT` / `SQLITE_NOTADB` errors still carry their `code` and still trigger the move-aside-and-recreate recovery in `getDb()`.

### 2. WAL fallback was silent
`PRAGMA journal_mode = WAL` failing was silently ignored. On some filesystems (network/overlay mounts) WAL can't be set and SQLite falls back to rollback-journal mode, sharply raising `SQLITE_BUSY` under parallel runs. We now read back the effective `journal_mode` and emit a `console.warn` if it isn't `wal`. No throw — just surfaces the degraded mode.

## Tests
Extends `tests/db-durability.test.ts` with a regression test proving a non-duplicate migration error propagates while a duplicate-column re-run stays idempotent. Verified it fails without the fix (broad-swallow revert → `Missing expected exception`).

- `npm run typecheck` clean
- `node --import tsx --test tests/db-durability.test.ts` — 8/8 pass
- `npm run selftest` — 26 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)