### PR TITLE
fix(grader): honor run AbortSignal so cancelled runs kill in-flight graders

### DIFF
--- a/lib/grader/index.ts
+++ b/lib/grader/index.ts
@@ -9,7 +9,7 @@ import { JUDGE_PROMPT_MARKER } from "../insights/signals";
 import { resolveWithin } from "../config";
 import type { CaseEvaluation, GraderResult, GraderSpec, RunnerResult } from "../types";
 
-function runProcess(bin: string, args: string[], spec: { cwd?: string; env?: Record<string, string>; timeout_ms?: number }): Promise<{ code: number; stdout: string; stderr: string; durationMs: number; timedOut: boolean }> {
+function runProcess(bin: string, args: string[], spec: { cwd?: string; env?: Record<string, string>; timeout_ms?: number; signal?: AbortSignal }): Promise<{ code: number; stdout: string; stderr: string; durationMs: number; timedOut: boolean }> {
   return new Promise((resolve) => {
     const start = Date.now();
     const env = { ...process.env, ...(spec.env || {}) };
@@ -23,8 +23,18 @@ function runProcess(bin: string, args: string[], spec: { cwd?: string; env?: Rec
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (spec.signal) spec.signal.removeEventListener("abort", onAbort);
       unregisterProcessGroup();
       resolve({ code, stdout: out, stderr: err, durationMs: Date.now() - start, timedOut: timedOutFlag });
+    };
+    // When the run is cancelled, kill the grader's process group immediately
+    // rather than letting it run out its own timeout. The 'close' handler
+    // resolves promptly once the process dies; the 1s timer is only a backstop
+    // in case the kill leaves nothing to emit 'close'.
+    const onAbort = () => {
+      timedOut = true;
+      killProcessGroup(p);
+      setTimeout(() => finish(124, true), 1000);
     };
     p.stdout.on("data", (c) => (out = appendCapped(out, c.toString())));
     p.stderr.on("data", (c) => (err = appendCapped(err, c.toString())));
@@ -37,10 +47,14 @@ function runProcess(bin: string, args: string[], spec: { cwd?: string; env?: Rec
     p.on("close", (code) => {
       finish(timedOut ? 124 : code ?? 1, timedOut);
     });
+    if (spec.signal) {
+      if (spec.signal.aborted) onAbort();
+      else spec.signal.addEventListener("abort", onAbort);
+    }
   });
 }
 
-function runShell(spec: { command: string; cwd?: string; env?: Record<string, string>; timeout_ms?: number }): Promise<{ code: number; stdout: string; stderr: string; durationMs: number; timedOut: boolean }> {
+function runShell(spec: { command: string; cwd?: string; env?: Record<string, string>; timeout_ms?: number; signal?: AbortSignal }): Promise<{ code: number; stdout: string; stderr: string; durationMs: number; timedOut: boolean }> {
   return runProcess("bash", ["-lc", spec.command], spec);
 }
 
@@ -104,13 +118,13 @@ function escapedEvidencePath(spec: GraderSpec, relative: string, durationMs: num
 
 export async function runGrader(
   spec: GraderSpec,
-  ctx: { workdir: string; runner: RunnerResult; transcriptText: string; fixtureSrc?: string }
+  ctx: { workdir: string; runner: RunnerResult; transcriptText: string; fixtureSrc?: string; signal?: AbortSignal }
 ): Promise<GraderResult> {
   const start = Date.now();
   const dur = () => Date.now() - start;
 
   if (spec.type === "exit_code" || spec.type === "tests_pass") {
-    const res = await runShell({ command: spec.command, cwd: spec.cwd ? path.resolve(ctx.workdir, spec.cwd) : ctx.workdir, env: spec.env, timeout_ms: spec.timeout_ms });
+    const res = await runShell({ command: spec.command, cwd: spec.cwd ? path.resolve(ctx.workdir, spec.cwd) : ctx.workdir, env: spec.env, timeout_ms: spec.timeout_ms, signal: ctx.signal });
     if (res.timedOut) {
       return fail(spec, `timeout after ${res.durationMs}ms`, dur(), `${res.stdout}\n${res.stderr}`.slice(0, 2000));
     }
@@ -267,9 +281,9 @@ export async function runGrader(
     // diffing HEAD keeps staged agent work visible — then fall back to a plain
     // worktree diff when HEAD does not exist (no commits yet).
     const pathArgs = spec.pathFilter ? ["--", spec.pathFilter] : [];
-    let res = await runProcess("git", ["diff", "HEAD", "--no-color", ...pathArgs], { cwd: ctx.workdir, timeout_ms: 10_000 });
+    let res = await runProcess("git", ["diff", "HEAD", "--no-color", ...pathArgs], { cwd: ctx.workdir, timeout_ms: 10_000, signal: ctx.signal });
     if (res.code !== 0) {
-      res = await runProcess("git", ["diff", "--no-color", ...pathArgs], { cwd: ctx.workdir, timeout_ms: 10_000 });
+      res = await runProcess("git", ["diff", "--no-color", ...pathArgs], { cwd: ctx.workdir, timeout_ms: 10_000, signal: ctx.signal });
     }
     const diff = res.stdout;
     try {

--- a/tests/grader.test.ts
+++ b/tests/grader.test.ts
@@ -278,6 +278,35 @@ test("tests_pass rejects vacuous zero-test success unless explicitly allowed", a
   });
 });
 
+test("exit_code grader aborts promptly when the run signal fires", async () => {
+  await withWorkdir(async (dir) => {
+    const controller = new AbortController();
+    const ctx = { ...ctxFor(dir), signal: controller.signal };
+    // Long-running grader with a timeout far past the abort window, so only the
+    // AbortSignal (not the 30s default or this timeout) can end it early.
+    // Without the signal plumbing the sleep runs its full duration.
+    const started = Date.now();
+    const pending = runGrader({ type: "exit_code", command: "sleep 30", timeout_ms: 60_000 }, ctx);
+    const abortTimer = setTimeout(() => controller.abort(), 100);
+    const r = await pending;
+    clearTimeout(abortTimer);
+    const elapsed = Date.now() - started;
+    assert.equal(r.passed, false);
+    assert.ok(elapsed < 5000, `expected prompt abort, took ${elapsed}ms`);
+  });
+});
+
+test("already-aborted signal short-circuits the grader without waiting the timeout", async () => {
+  await withWorkdir(async (dir) => {
+    const ctx = { ...ctxFor(dir), signal: AbortSignal.abort() };
+    const started = Date.now();
+    const r = await runGrader({ type: "exit_code", command: "sleep 30", timeout_ms: 60_000 }, ctx);
+    const elapsed = Date.now() - started;
+    assert.equal(r.passed, false);
+    assert.ok(elapsed < 5000, `expected immediate abort, took ${elapsed}ms`);
+  });
+});
+
 test("shell grader caps retained output at MAX_RETAINED_BYTES", async () => {
   await withWorkdir(async (dir) => {
     const r = await runGrader(


### PR DESCRIPTION
## Problem

`lib/grader/index.ts` ran grader shell subprocesses but ignored the run's `AbortSignal`. When a run was cancelled, an in-flight grader kept running to its own 30s timeout instead of being killed with the case. Process-group cleanup and the force-resolve fallback meant no leak — but cancellation was delayed by up to the full timeout.

## Change

- `runProcess`/`runShell` now accept an optional `signal`. On abort they kill the grader's process group immediately; the existing `close` handler resolves promptly, and the 1s timer remains as a backstop.
- `runGrader`'s `ctx` gains an optional `signal?: AbortSignal`, plumbed into the `exit_code`/`tests_pass` shell call and both `git_diff_contains` git spawns.
- The 30s timeout and force-resolve fallback are preserved as the backstop.
- The signal is optional and defaults to `undefined`, so existing callers (executor, selftest) compile unchanged. The executor already holds the run's `signal` in `executeCase`; wiring it into the grading loop is a trivial follow-up in that file's own scope.

Change is confined to `lib/grader/index.ts` plus tests.

## Tests

`tests/grader.test.ts` gains two regression tests: aborting the signal (and passing an already-aborted signal) ends a slow `sleep 30` grader in well under 5s instead of running to its timeout. Verified the first test fails without the fix (runs the full sleep). All 33 grader tests pass; `npm run typecheck` and `npm run selftest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)