### PR TITLE
Harden subprocess lifecycle in spawnHarnessProcess

### DIFF
--- a/lib/runner/spawn.ts
+++ b/lib/runner/spawn.ts
@@ -16,14 +16,35 @@ export interface SpawnHarnessResult {
 /** Max bytes retained per stream, so a runaway harness can't OOM the eval. */
 export const MAX_RETAINED_BYTES = 8 * 1024 * 1024;
 
-/** Kill a detached child and every process it spawned. */
-export function killProcessGroup(proc: ChildProcess): void {
-  try {
-    if (proc.pid) process.kill(-proc.pid, "SIGKILL");
-    else proc.kill("SIGKILL");
-  } catch {
-    try { proc.kill("SIGKILL"); } catch {}
-  }
+/**
+ * How long after a kill to force-resolve the spawn promise if 'close' never
+ * fires. Kept above killProcessGroup's SIGTERM→SIGKILL grace (2s) so a process
+ * that would exit on the escalation still gets the chance to close naturally.
+ */
+export const FORCE_RESOLVE_AFTER_KILL_MS = 3000;
+
+/**
+ * Kill a detached child and every process it spawned. Escalates: a graceful
+ * SIGTERM first, then SIGKILL after `graceMs` if the process is still alive, so
+ * well-behaved harnesses can flush and exit cleanly while stuck ones are still
+ * force-killed. Safe to call when the process is already gone.
+ */
+export function killProcessGroup(proc: ChildProcess, graceMs = 2000): void {
+  const signalGroup = (signal: NodeJS.Signals) => {
+    try {
+      if (proc.pid) process.kill(-proc.pid, signal);
+      else proc.kill(signal);
+    } catch {
+      try { proc.kill(signal); } catch {}
+    }
+  };
+  signalGroup("SIGTERM");
+  const escalation = setTimeout(() => {
+    // Only escalate if the process has not already exited.
+    if (proc.exitCode == null && proc.signalCode == null) signalGroup("SIGKILL");
+  }, graceMs);
+  // Don't let the grace timer keep the event loop (or a test) alive.
+  escalation.unref?.();
 }
 
 // Detached children need an explicit parent-exit cleanup path. Keep the
@@ -157,11 +178,24 @@ export function spawnHarnessProcess(ctx: RunnerContext, onLine: (line: string, a
       detached: true,
     });
     const unregisterProcessGroup = registerProcessGroup(proc);
-    // Cancellation mirrors the timeout path: SIGKILL the whole process group
+
+    let settled = false;
+    let killForceTimer: ReturnType<typeof setTimeout> | null = null;
+    // Belt-and-suspenders: after a kill, 'close' normally resolves the promise,
+    // but if it is delayed or never fires (stuck grandchild holding the pipe,
+    // lost SIGCHLD) the runner would hang forever. Force-resolve as timed-out.
+    const scheduleForceResolve = () => {
+      if (killForceTimer || settled) return;
+      killForceTimer = setTimeout(() => finish(124), FORCE_RESOLVE_AFTER_KILL_MS);
+      killForceTimer.unref?.();
+    };
+
+    // Cancellation mirrors the timeout path: kill the whole process group
     // so agent-spawned grandchildren cannot outlive an aborted case.
     const onAbort = () => {
       aborted = true;
       killProcessGroup(proc);
+      scheduleForceResolve();
     };
     if (ctx.signal?.aborted) onAbort();
     else ctx.signal?.addEventListener("abort", onAbort, { once: true });
@@ -174,20 +208,27 @@ export function spawnHarnessProcess(ctx: RunnerContext, onLine: (line: string, a
     const timer = setTimeout(() => {
       timedOut = true;
       killProcessGroup(proc);
+      scheduleForceResolve();
     }, ctx.timeoutMs);
 
     proc.stdout?.on("data", (chunk: Buffer) => {
       const text = chunk.toString();
       stdout = appendCapped(stdout, text);
-      stdoutBuf = drainLineBuffer(stdoutBuf + text, (line) => onLine(line, acc));
+      // A throw from onLine (adapter.parseLine → onEvent → synchronous SQLite
+      // appendEvent, which can raise SQLITE_BUSY) would otherwise escape this
+      // 'data' handler uncaught and abort the whole process, killing every
+      // parallel worker. Swallow per-line like the flush path below does.
+      stdoutBuf = drainLineBuffer(stdoutBuf + text, (line) => {
+        try { onLine(line, acc); } catch {}
+      });
     });
     proc.stderr?.on("data", (c: Buffer) => { stderr = appendCapped(stderr, c.toString()); });
 
-    let settled = false;
     const finish = (exitCode: number) => {
       if (settled) return; // 'error' and 'close' can both fire; flush only once
       settled = true;
       clearTimeout(timer);
+      if (killForceTimer) clearTimeout(killForceTimer);
       unregisterProcessGroup();
       ctx.signal?.removeEventListener("abort", onAbort);
       if (stdoutBuf.trim()) {

--- a/tests/spawn.test.ts
+++ b/tests/spawn.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { appendCapped, drainLineBuffer } from "../lib/runner/spawn";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { appendCapped, drainLineBuffer, spawnHarnessProcess } from "../lib/runner/spawn";
 import { normalizeParsedResult } from "../lib/runner/headless";
 import { paneCaptureDelta } from "../lib/runner/tmux";
 import { parseCodexLine } from "../lib/adapters/codex";
@@ -163,6 +166,79 @@ test("runner normalization uses the requested model instead of a synthetic senti
   assert.equal(result.model, "gpt-5.5");
   assert.equal(result.usage.costSource, "inferred");
   assert.equal(result.usage.costUsd, estimateCostUsd("gpt-5.5", { input: 100, output: 10, cacheRead: 0, cacheCreate: 0 }));
+});
+
+// ---- spawnHarnessProcess subprocess lifecycle ----
+
+function makeExecutable(dir: string, name: string, body: string): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, body, { mode: 0o755 });
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function ncodeCtx(dir: string, timeoutMs: number) {
+  return {
+    caseId: "spawn-regression",
+    workdir: dir,
+    prompt: "noop",
+    maxTurns: 1,
+    timeoutMs,
+    permissionMode: "default" as const,
+    extraArgs: [] as string[],
+    harness: "ncode",
+  };
+}
+
+test("spawnHarnessProcess does not crash when onLine throws on every line", async () => {
+  // Regression: an uncaught throw from onLine (adapter.parseLine → onEvent →
+  // synchronous SQLite appendEvent, e.g. SQLITE_BUSY) inside the stdout 'data'
+  // handler would abort the whole eval process and kill all parallel workers.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-spawn-"));
+  const prevBin = process.env.NCODE_BIN;
+  try {
+    process.env.NCODE_BIN = makeExecutable(
+      dir,
+      "fake-ncode.sh",
+      "#!/bin/sh\nprintf '{\"type\":\"a\"}\\n'\nprintf 'second line\\n'\nexit 0\n",
+    );
+    let calls = 0;
+    const result = await spawnHarnessProcess(ncodeCtx(dir, 10_000), () => {
+      calls += 1;
+      throw new Error("appendEvent blew up (SQLITE_BUSY)");
+    });
+    assert.ok(calls > 0, "onLine should have been invoked");
+    assert.equal(result.timedOut, false);
+    assert.equal(result.aborted, false);
+    assert.equal(result.exitCode, 0);
+  } finally {
+    if (prevBin === undefined) delete process.env.NCODE_BIN;
+    else process.env.NCODE_BIN = prevBin;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("spawnHarnessProcess escalates to SIGKILL and resolves a SIGTERM-ignoring child on timeout", async () => {
+  // Regression: killProcessGroup used to send SIGKILL only; a child that traps
+  // SIGTERM still dies, but the run must escalate and resolve rather than hang.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openeval-spawn-"));
+  const prevBin = process.env.NCODE_BIN;
+  try {
+    process.env.NCODE_BIN = makeExecutable(
+      dir,
+      "stubborn-ncode.sh",
+      "#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 0.2; done\n",
+    );
+    const start = Date.now();
+    const result = await spawnHarnessProcess(ncodeCtx(dir, 300), () => {});
+    assert.equal(result.timedOut, true);
+    // Resolves after the timeout + SIGTERM→SIGKILL grace, but well before hanging.
+    assert.ok(Date.now() - start < 20_000, "kill path must resolve promptly");
+  } finally {
+    if (prevBin === undefined) delete process.env.NCODE_BIN;
+    else process.env.NCODE_BIN = prevBin;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("paneCaptureDelta avoids reparsing an unchanged final tmux snapshot", () => {


### PR DESCRIPTION
Three subprocess-lifecycle robustness fixes confined to lib/runner/spawn.ts.

1. Wrap the per-line onLine call in the stdout data handler in try/catch, matching the flush path. onLine to adapter.parseLine to onEvent to a synchronous SQLite appendEvent can throw (e.g. SQLITE_BUSY); an uncaught throw here aborted the whole eval process and killed all parallel workers.

2. Add a belt-and-suspenders force-resolve timer after a kill. If close is delayed or never fires the runner would hang forever; now it force-resolves as timed-out (mirrors lib/grader/index.ts). Timer is unref'd and cleared in finish.

3. Escalate killProcessGroup from SIGKILL-only to SIGTERM then SIGKILL after a 2s grace, so well-behaved harnesses can flush and exit cleanly while stuck ones are still force-killed. Safe when already gone; grace timer is unref'd.

Tests: extended tests/spawn.test.ts with two regressions (an onLine that throws on every line must not crash the run — fails without fix 1; a SIGTERM-ignoring child must still be killed and resolve as timed out). typecheck, spawn (16), robustness (5), and selftest (26) all pass.

Generated with Claude Code