### PR TITLE
Harden tmux runner: tail retention, incremental reads, workdir isolation, exit cleanup

### DIFF
--- a/lib/runner/tmux.ts
+++ b/lib/runner/tmux.ts
@@ -1,5 +1,8 @@
-import { spawn } from "node:child_process";
-import { rm, writeFile, readFile } from "node:fs/promises";
+import { spawn, spawnSync } from "node:child_process";
+import { rm, writeFile, open, type FileHandle } from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
+import os from "node:os";
 import path from "node:path";
 import { getAdapter } from "../adapters/registry";
 import { resolveDefaultModel } from "../models";
@@ -39,6 +42,97 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/** Cap on how many bytes a single tail read pulls, so one tick can't allocate an unbounded buffer. */
+const TAIL_READ_CHUNK = 8 * 1024 * 1024;
+
+/**
+ * Streaming tail reader for an append-only log. Tracks a byte offset and reads
+ * only the bytes appended since the last call, so polling a growing logfile is
+ * O(total) instead of O(n²) (the previous code re-read and re-decoded the whole
+ * file every tick). Because reads follow the tail, a completion event at the END
+ * of a multi-megabyte session is always observed — the old `slice(0, 8MB)`
+ * front-truncation dropped it. A StringDecoder preserves multi-byte UTF-8
+ * sequences that straddle a read boundary.
+ */
+export function makeTailReader(handle: FileHandle, chunkBytes = TAIL_READ_CHUNK) {
+  const decoder = new StringDecoder("utf8");
+  let offset = 0;
+  return {
+    /** Read the next appended slice (up to `chunkBytes`); "" when nothing new. */
+    async read(): Promise<string> {
+      const { size } = await handle.stat();
+      if (size <= offset) return "";
+      const len = Math.min(size - offset, chunkBytes);
+      const buf = Buffer.allocUnsafe(len);
+      const { bytesRead } = await handle.read(buf, 0, len, offset);
+      if (bytesRead <= 0) return "";
+      offset += bytesRead;
+      return decoder.write(buf.subarray(0, bytesRead));
+    },
+    /** Flush any bytes the decoder buffered for an incomplete final sequence. */
+    end(): string {
+      return decoder.end();
+    },
+    /** Drain everything appended so far, looping past the per-read cap. */
+    async drain(): Promise<string> {
+      let all = "";
+      for (;;) {
+        const next = await this.read();
+        if (!next) break;
+        all += next;
+      }
+      return all + this.end();
+    },
+    get offset() {
+      return offset;
+    },
+  };
+}
+
+// tmux daemonizes: its detached server and the agent subtree survive a parent
+// crash/restart even though we hold no ChildProcess handle for the session.
+// Mirror spawn.ts's process-group registry, but keyed on session name, and tear
+// down synchronously (spawnSync) at parent exit — an async kill never runs on
+// 'exit'. Kept on globalThis so Next dev HMR reuses one handler set.
+interface TmuxSessionRegistry {
+  sessions: Map<string, string>; // session name -> logfile to unlink
+  installed: boolean;
+}
+
+const tmuxSessionRegistry = (() => {
+  const key = "__openevalTmuxSessions";
+  const root = globalThis as typeof globalThis & Record<string, unknown>;
+  if (!root[key]) root[key] = { sessions: new Map<string, string>(), installed: false } satisfies TmuxSessionRegistry;
+  return root[key] as TmuxSessionRegistry;
+})();
+
+function killRegisteredTmuxSessions(): void {
+  for (const [session, logPath] of tmuxSessionRegistry.sessions) {
+    try { spawnSync("tmux", ["kill-session", "-t", session], { stdio: "ignore" }); } catch {}
+    try { rmSync(logPath, { force: true }); } catch {}
+  }
+  tmuxSessionRegistry.sessions.clear();
+}
+
+function ensureTmuxCleanupHandlers(): void {
+  if (tmuxSessionRegistry.installed) return;
+  tmuxSessionRegistry.installed = true;
+  process.once("exit", killRegisteredTmuxSessions);
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.once(signal, () => {
+      killRegisteredTmuxSessions();
+      process.removeAllListeners(signal);
+      process.kill(process.pid, signal);
+    });
+  }
+}
+
+function registerTmuxSession(session: string, logPath: string): () => void {
+  ensureTmuxCleanupHandlers();
+  tmuxSessionRegistry.sessions.set(session, logPath);
+  return () => { tmuxSessionRegistry.sessions.delete(session); };
+}
+
 export class TmuxRunner implements Runner {
   kind = "tmux" as const;
 
@@ -70,7 +164,10 @@ export class TmuxRunner implements Runner {
     // A very short-lived harness can finish before tmux's pane capture is
     // observable. Persist the merged stream from inside the shell so the
     // runner retains result events even when the session disappears quickly.
-    const logPath = path.join(ctx.workdir, `.openeval-tmux-${session}.jsonl`);
+    // The log lives OUTSIDE ctx.workdir: the workdir is the graded directory,
+    // so a file-listing / glob grader must never observe this eval-internal
+    // artifact mid-run.
+    const logPath = path.join(os.tmpdir(), `openeval-tmux-${session}.jsonl`);
     await writeFile(logPath, "", "utf8");
     const loggedShellCmd = `${shellCmd} 2>&1 | tee ${shellQuote(logPath)}`;
     const newSession = await tmux([
@@ -83,45 +180,69 @@ export class TmuxRunner implements Runner {
       return fail(ctx, acc, startedAt, `tmux new-session failed: ${newSession.stderr}`);
     }
 
-    let lastCapture = "";
-    const readCapture = async () => {
-      const output = await readFile(logPath, "utf8").catch(() => "");
-      return output.slice(0, 8 * 1024 * 1024);
+    // Register for parent-exit teardown as soon as the session is live, so a
+    // crash between here and cleanup still reaps the detached tmux server.
+    const unregisterSession = registerTmuxSession(session, logPath);
+
+    const handle = await open(logPath, "r").catch(() => null);
+    const tailReader = handle ? makeTailReader(handle) : null;
+    let lineBuffer = "";
+    // Parse only complete lines each tick; a fragment split across a read
+    // boundary is held until the newline arrives. The raw appended text is
+    // still streamed to the live log verbatim.
+    const consume = (delta: string) => {
+      if (!delta) return;
+      emit(ctx, { kind: "log", stream: "stdout", chunk: delta, at: Date.now() });
+      lineBuffer += delta;
+      const parts = lineBuffer.split("\n");
+      lineBuffer = parts.pop() ?? "";
+      for (const line of parts) {
+        for (const ev of adapter.parseLine(line, acc)) emit(ctx, ev);
+      }
     };
+    const flushLineBuffer = () => {
+      if (!lineBuffer) return;
+      for (const ev of adapter.parseLine(lineBuffer, acc)) emit(ctx, ev);
+      lineBuffer = "";
+    };
+
     const deadline = startedAt + ctx.timeoutMs;
     let cancelled = false;
-    while (Date.now() < deadline) {
-      // Cancellation: stop polling and let the kill-session below tear down
-      // the pane's process tree (tmux HUPs pane processes on session kill).
-      if (ctx.signal?.aborted) {
-        cancelled = true;
-        break;
-      }
-      const capture = await readCapture();
-      if (capture !== lastCapture) {
-        const diff = paneCaptureDelta(lastCapture, capture);
-        lastCapture = capture;
-        emit(ctx, { kind: "log", stream: "stdout", chunk: diff, at: Date.now() });
-        for (const line of diff.split("\n")) {
-          for (const ev of adapter.parseLine(line, acc)) emit(ctx, ev);
+    try {
+      while (Date.now() < deadline) {
+        // Cancellation: stop polling and let the kill-session below tear down
+        // the pane's process tree (tmux HUPs pane processes on session kill).
+        if (ctx.signal?.aborted) {
+          cancelled = true;
+          break;
         }
+        if (tailReader) consume(await tailReader.read());
+
+        // No shell here: "2>/dev/null" would be passed as a literal arg and make
+        // `tmux ls` error out, breaking the poll loop on its first iteration.
+        const list = await tmux(["ls", "-F", "#{session_name}"]);
+        if (!list.stdout.split("\n").includes(session)) break;
+        await sleep(400);
       }
 
-      // No shell here: "2>/dev/null" would be passed as a literal arg and make
-      // `tmux ls` error out, breaking the poll loop on its first iteration.
-      const list = await tmux(["ls", "-F", "#{session_name}"]);
-      if (!list.stdout.split("\n").includes(session)) break;
-      await sleep(400);
+      // Drain everything the harness appended after the last poll, including a
+      // completion event written just before the session ended. Consume one
+      // capped chunk at a time so a huge post-poll tail can't be buffered whole.
+      if (tailReader) {
+        for (;;) {
+          const chunk = await tailReader.read();
+          if (!chunk) break;
+          consume(chunk);
+        }
+        consume(tailReader.end());
+      }
+      flushLineBuffer();
+    } finally {
+      await tmux(["kill-session", "-t", session]).catch(async () => ({ code: 0, stdout: "", stderr: "" }));
+      unregisterSession();
+      await handle?.close().catch(() => {});
+      await rm(logPath, { force: true });
     }
-
-    const finalCapture = await readCapture();
-    const remaining = paneCaptureDelta(lastCapture, finalCapture);
-    if (remaining) emit(ctx, { kind: "log", stream: "stdout", chunk: remaining, at: Date.now() });
-    for (const line of remaining.split("\n")) {
-      for (const ev of adapter.parseLine(line, acc)) emit(ctx, ev);
-    }
-    await tmux(["kill-session", "-t", session]).catch(async () => ({ code: 0, stdout: "", stderr: "" }));
-    await rm(logPath, { force: true });
 
     const durationMs = Date.now() - startedAt;
     const exitCode = acc.result?.isError ? 1 : 0;

--- a/tests/robustness.test.ts
+++ b/tests/robustness.test.ts
@@ -1,8 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import os from "node:os";
+import { mkdtemp, open, writeFile, appendFile, rm } from "node:fs/promises";
 import { resolveWithin } from "../lib/config";
 import { safeParse } from "../lib/db";
+import { makeTailReader } from "../lib/runner/tmux";
 
 // ---- resolveWithin (artifact path safety) ----
 
@@ -40,4 +43,78 @@ test("safeParse falls back on null, undefined, and corrupt JSON", () => {
   assert.equal(safeParse(undefined, fallback), fallback);
   assert.equal(safeParse("{truncated", fallback), fallback);
   assert.equal(safeParse("", fallback), fallback);
+});
+
+// ---- makeTailReader (tmux log tail retention + incremental reads) ----
+
+test("makeTailReader retains the completion event past the 8 MB front-truncation limit", async () => {
+  // Regression for the tmux `output.slice(0, 8MB)` bug: the terminal `result`
+  // event lives at the END of a long session, so anything beyond 8 MB was
+  // dropped and the run always fell to a timeout/fail.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openeval-tail-"));
+  const file = path.join(dir, "log.jsonl");
+  const filler = "x".repeat(1024) + "\n"; // 1 KiB per line
+  const lines = 9 * 1024; // ~9 MiB of filler, past the old 8 MiB cap
+  const completion = '{"type":"result","result":"done past 8mb"}';
+  try {
+    await writeFile(file, "", "utf8");
+    // Small per-read chunk so drain() must loop across the cap boundary.
+    const handle = await open(file, "r");
+    try {
+      const reader = makeTailReader(handle, 64 * 1024);
+      await appendFile(file, filler.repeat(lines) + completion + "\n", "utf8");
+      const all = await reader.drain();
+      const parsed = all.trimEnd().split("\n");
+      assert.equal(parsed[parsed.length - 1], completion, "completion event beyond 8 MB must survive");
+      assert.ok(reader.offset > 8 * 1024 * 1024, "reader advanced past the old 8 MB truncation point");
+    } finally {
+      await handle.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("makeTailReader reads only appended bytes across successive ticks", async () => {
+  // Regression for the O(n²) poll: each tick must read only the newly appended
+  // tail, never re-decode the whole growing file.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openeval-tail-"));
+  const file = path.join(dir, "log.jsonl");
+  try {
+    await writeFile(file, "first\n", "utf8");
+    const handle = await open(file, "r");
+    try {
+      const reader = makeTailReader(handle);
+      assert.equal(await reader.read(), "first\n");
+      assert.equal(await reader.read(), "", "no new bytes yet");
+      await appendFile(file, "second\n", "utf8");
+      assert.equal(await reader.read(), "second\n", "only the appended delta, not the whole file");
+      assert.equal(reader.offset, "first\nsecond\n".length);
+    } finally {
+      await handle.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("makeTailReader preserves a multi-byte UTF-8 char split across a read boundary", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openeval-tail-"));
+  const file = path.join(dir, "log.jsonl");
+  try {
+    // "😀" is 4 UTF-8 bytes; a 2-byte chunk forces the split.
+    await writeFile(file, "😀\n", "utf8");
+    const handle = await open(file, "r");
+    try {
+      const reader = makeTailReader(handle, 2);
+      let out = "";
+      out += await reader.read();
+      out += await reader.drain();
+      assert.equal(out, "😀\n", "surrogate must not be corrupted by the byte-boundary split");
+    } finally {
+      await handle.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Four robustness fixes confined to `lib/runner/tmux.ts`.

1. **Tail retention (correctness)** — `readCapture` did `output.slice(0, 8MB)`, keeping the FIRST 8 MB. The terminal `result` event is at the END of a session, so any session over 8 MB never saw its completion event (`isCompleteResult` stayed false) and always fell to timeout/fail. Reads now follow the tail via a byte offset, so the completion event is always observed regardless of session size.

2. **O(n²) polling I/O** — the full growing logfile was re-read and re-decoded on every ~400 ms poll. New `makeTailReader` tracks a byte offset and reads only the bytes appended since the last tick. A `StringDecoder` preserves multi-byte UTF-8 sequences split across a read boundary, and line parsing now buffers partial lines so a fragment split across a read boundary is not mis-parsed.

3. **Workdir pollution** — the `.openeval-tmux-<session>.jsonl` log was written inside `ctx.workdir` (the graded directory), where a file-listing/glob grader could observe an eval-internal artifact mid-run. It now lives in `os.tmpdir()`; cleanup still removes it.

4. **Exit cleanup** — unlike `lib/runner/spawn.ts`, the tmux runner never registered its detached tmux server + agent subtree with a parent-exit teardown, so a crash/restart left them running. Mirrors spawn.ts's process-group registry, keyed on session name, tearing down synchronously (`spawnSync`) on `exit`/`SIGINT`/`SIGTERM`/`SIGHUP`.

## Tests

- Added `makeTailReader` regression tests to `tests/robustness.test.ts`: completion event beyond 8 MB survives; only appended bytes are read per tick; multi-byte UTF-8 char split across a read boundary is preserved.
- `npm run typecheck`, `npm run selftest`, and the tmux-exercising suites (`tests/pending-gaps.test.ts`, `tests/executor-edges.test.ts` — real tmux, not skipped) all pass, plus `test:live` and `test:telemetry`.

Existing exports and behavior preserved (`paneCaptureDelta` retained and still covered by `tests/spawn.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)