### PR TITLE
evals: expand visual-code with 3 new cases (mermaid, responsive grid, sortable table)

### DIFF
--- a/cases/visual-code/oracle/visual-mermaid-pipeline-diagram-bad.sh
+++ b/cases/visual-code/oracle/visual-mermaid-pipeline-diagram-bad.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Plausibly-wrong: a flowchart that drops the Executor-->Grade edge and the
+# labeled known-bad rejection edge, so the pipeline no longer connects end to end.
+cat > pipeline.mmd <<'MMD'
+flowchart TD
+  SelectCases --> RunLoop
+  RunLoop --> Executor
+  Grade --> Persist
+MMD

--- a/cases/visual-code/oracle/visual-mermaid-pipeline-diagram.sh
+++ b/cases/visual-code/oracle/visual-mermaid-pipeline-diagram.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > pipeline.mmd <<'MMD'
+flowchart TD
+  SelectCases --> RunLoop
+  RunLoop --> Executor
+  Executor --> Grade
+  Grade --> Persist
+  Grade -->|known-bad| Persist
+MMD

--- a/cases/visual-code/oracle/visual-responsive-pricing-grid-bad.sh
+++ b/cases/visual-code/oracle/visual-responsive-pricing-grid-bad.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Plausibly-wrong: a fixed three-column grid with NO responsive @media query,
+# so it never collapses to a single column on narrow viewports.
+cat > pricing.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>OpenEval Pricing</title>
+    <link rel="stylesheet" href="pricing.css">
+  </head>
+  <body>
+    <main data-testid="pricing" class="pricing">
+      <header><h1>Choose your plan</h1></header>
+      <section class="grid">
+        <article data-testid="plan-card"><h2>Free</h2><p>$0</p></article>
+        <article data-testid="plan-card"><h2>Team</h2><p>$49</p></article>
+        <article data-testid="plan-card"><h2>Enterprise</h2><p>Contact us</p></article>
+      </section>
+    </main>
+  </body>
+</html>
+HTML
+cat > pricing.css <<'CSS'
+body { margin: 0; background: #080a0f; color: #edf2f7; font-family: Inter, sans-serif; }
+.pricing { max-width: 1080px; margin: 48px auto; }
+.grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
+[data-testid="plan-card"] { border: 1px solid #273142; padding: 24px; border-radius: 12px; }
+CSS

--- a/cases/visual-code/oracle/visual-responsive-pricing-grid.sh
+++ b/cases/visual-code/oracle/visual-responsive-pricing-grid.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > pricing.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OpenEval Pricing</title>
+    <link rel="stylesheet" href="pricing.css">
+  </head>
+  <body>
+    <main data-testid="pricing" class="pricing">
+      <header class="pricing__head">
+        <h1>Choose your plan</h1>
+        <p>Deterministic evals, known-bad rejection, and visual-code coverage — priced by team size.</p>
+      </header>
+      <section class="grid" aria-label="plans">
+        <article data-testid="plan-card" class="card">
+          <h2>Free</h2>
+          <p class="price">$0</p>
+          <ul><li>Single harness</li><li>Local runs</li></ul>
+        </article>
+        <article data-testid="plan-card" class="card card--featured">
+          <h2>Team</h2>
+          <p class="price">$49</p>
+          <ul><li>Cross-harness pass@k</li><li>Shared dashboard</li></ul>
+        </article>
+        <article data-testid="plan-card" class="card">
+          <h2>Enterprise</h2>
+          <p class="price">Contact us</p>
+          <ul><li>SSO + audit</li><li>Priority support</li></ul>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>
+HTML
+cat > pricing.css <<'CSS'
+:root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+body { margin: 0; background: #080a0f; color: #edf2f7; }
+.pricing { width: min(1080px, calc(100vw - 48px)); margin: 48px auto; }
+.pricing__head h1 { margin: 0 0 8px; font-size: 40px; }
+.pricing__head p { margin: 0 0 28px; max-width: 560px; color: #9aa4b2; line-height: 1.5; }
+.grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
+.card { border: 1px solid #273142; background: #111827; border-radius: 12px; padding: 24px; }
+.card--featured { border-color: #7c5cff; }
+.card h2 { margin: 0 0 12px; font-size: 22px; }
+.price { font-size: 32px; font-weight: 700; margin: 0 0 16px; }
+.card ul { margin: 0; padding-left: 18px; color: #9aa4b2; line-height: 1.7; }
+@media (max-width: 640px) {
+  .grid { grid-template-columns: 1fr; }
+  .pricing__head h1 { font-size: 30px; }
+}
+CSS

--- a/cases/visual-code/oracle/visual-sortable-results-table-bad.sh
+++ b/cases/visual-code/oracle/visual-sortable-results-table-bad.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Plausibly-wrong: a static results table with no sort-key attributes, no
+# scope/aria-sort affordances, and no click handler — it renders but never sorts.
+cat > results-table.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Case Results</title>
+    <style>
+      body { margin: 0; background: #080a0f; color: #edf2f7; font-family: Inter, sans-serif; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid #273142; }
+    </style>
+  </head>
+  <body>
+    <main data-testid="results-table">
+      <h1>Case Results</h1>
+      <table>
+        <thead>
+          <tr><th>Case</th><th>Score</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>visual-svg-status-card</td><td>0.94</td><td>passed</td></tr>
+          <tr><td>visual-web-eval-dashboard</td><td>0.88</td><td>passed</td></tr>
+          <tr><td>swe-fix-fizzbuzz</td><td>0.71</td><td>failed</td></tr>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>
+HTML

--- a/cases/visual-code/oracle/visual-sortable-results-table.sh
+++ b/cases/visual-code/oracle/visual-sortable-results-table.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat > results-table.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Case Results</title>
+    <style>
+      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+      body { margin: 0; background: #080a0f; color: #edf2f7; }
+      main { width: min(880px, calc(100vw - 48px)); margin: 40px auto; }
+      h1 { font-size: 34px; margin: 0 0 20px; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid #273142; }
+      th { color: #9aa4b2; cursor: pointer; user-select: none; background: #10151f; }
+      th[aria-sort="ascending"]::after { content: " \25B2"; }
+      th[aria-sort="descending"]::after { content: " \25BC"; }
+    </style>
+  </head>
+  <body>
+    <main data-testid="results-table">
+      <h1>Case Results</h1>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort-key="case" aria-sort="none">Case</th>
+            <th scope="col" data-sort-key="score" aria-sort="none">Score</th>
+            <th scope="col" data-sort-key="status" aria-sort="none">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>visual-svg-status-card</td><td data-value="0.94">0.94</td><td>passed</td></tr>
+          <tr><td>visual-web-eval-dashboard</td><td data-value="0.88">0.88</td><td>passed</td></tr>
+          <tr><td>swe-fix-fizzbuzz</td><td data-value="0.71">0.71</td><td>failed</td></tr>
+          <tr><td>single-tool-grep</td><td data-value="1.00">1.00</td><td>passed</td></tr>
+        </tbody>
+      </table>
+    </main>
+    <script>
+      (function () {
+        var table = document.querySelector("table");
+        var tbody = table.querySelector("tbody");
+        var headers = table.querySelectorAll("thead th[data-sort-key]");
+        headers.forEach(function (th, colIndex) {
+          th.addEventListener("click", function () {
+            var current = th.getAttribute("aria-sort");
+            var dir = current === "ascending" ? "descending" : "ascending";
+            headers.forEach(function (h) { h.setAttribute("aria-sort", "none"); });
+            th.setAttribute("aria-sort", dir);
+            var rows = Array.prototype.slice.call(tbody.querySelectorAll("tr"));
+            rows.sort(function (a, b) {
+              var ca = a.children[colIndex];
+              var cb = b.children[colIndex];
+              var va = ca.getAttribute("data-value") || ca.textContent.trim();
+              var vb = cb.getAttribute("data-value") || cb.textContent.trim();
+              var na = parseFloat(va), nb = parseFloat(vb);
+              var cmp = (!isNaN(na) && !isNaN(nb)) ? na - nb : va.localeCompare(vb);
+              return dir === "ascending" ? cmp : -cmp;
+            });
+            rows.forEach(function (r) { tbody.appendChild(r); });
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>
+HTML

--- a/cases/visual-code/visual-mermaid-pipeline-diagram.case.json
+++ b/cases/visual-code/visual-mermaid-pipeline-diagram.case.json
@@ -1,0 +1,34 @@
+{
+  "id": "visual-mermaid-pipeline-diagram",
+  "category": "visual-code",
+  "difficulty": "medium",
+  "name": "Author a Mermaid pipeline flowchart",
+  "description": "Visual-code task for blind-but-design-capable models: express the OpenEval execution pipeline as a Mermaid flowchart. Grading stays deterministic by asserting the required nodes and directed edges exist in the produced diagram source.",
+  "tags": ["visual-code", "mermaid", "diagram", "flowchart"],
+  "split": "public",
+  "prompt": "Create a file named pipeline.mmd containing a single Mermaid flowchart. Start it with a `flowchart TD` (or `graph TD`) header. Model the OpenEval execution pipeline with these labeled nodes: SelectCases, RunLoop, Executor, Grade, Persist. Connect them as a directed chain using `-->` edges so the flow reads SelectCases --> RunLoop --> Executor --> Grade --> Persist. Add one additional edge from Grade back to Persist labeled with a rejection path (for example `Grade -->|known-bad| Persist`). Do not create any other files.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 10, "timeout_seconds": 180, "permission_mode": "bypassPermissions" },
+  "budget": { "max_turns": 10, "max_cost_usd": 0.5 },
+  "visual": {
+    "kind": "web_ui",
+    "requires_vision_input": false,
+    "expected_artifacts": ["pipeline.mmd"]
+  },
+  "graders": [
+    { "type": "file_exists", "path": "pipeline.mmd", "weight": 10 },
+    { "type": "file_contains", "path": "pipeline.mmd", "pattern": "(flowchart|graph)\\s+(TD|TB|LR|RL|BT)", "weight": 15 },
+    { "type": "file_contains", "path": "pipeline.mmd", "pattern": "SelectCases\\s*-->\\s*RunLoop", "weight": 15 },
+    { "type": "file_contains", "path": "pipeline.mmd", "pattern": "RunLoop\\s*-->\\s*Executor", "weight": 15 },
+    { "type": "file_contains", "path": "pipeline.mmd", "pattern": "Executor\\s*-->\\s*Grade", "weight": 15 },
+    { "type": "file_contains", "path": "pipeline.mmd", "pattern": "Grade\\s*-->\\s*Persist", "weight": 15 },
+    { "type": "file_contains", "path": "pipeline.mmd", "pattern": "Grade\\s*-->\\|[^|]+\\|\\s*Persist", "weight": 10 },
+    { "type": "file_exists", "path": "index.html", "negate": true, "weight": 5, "forbidden": true }
+  ],
+  "pass_threshold": 0.85,
+  "oracle": {
+    "solve": "oracle/visual-mermaid-pipeline-diagram.sh",
+    "noop_max_score": 0.1,
+    "known_bad": ["oracle/visual-mermaid-pipeline-diagram-bad.sh"]
+  }
+}

--- a/cases/visual-code/visual-responsive-pricing-grid.case.json
+++ b/cases/visual-code/visual-responsive-pricing-grid.case.json
@@ -1,0 +1,38 @@
+{
+  "id": "visual-responsive-pricing-grid",
+  "category": "visual-code",
+  "difficulty": "medium",
+  "name": "Build a responsive pricing grid with a media query",
+  "description": "Visual-code task: produce a responsive three-tier pricing component that reflows at a mobile breakpoint. Grading stays deterministic by asserting the semantic markup plus a real CSS @media query with a max-width breakpoint that collapses the grid to a single column.",
+  "tags": ["visual-code", "web-ui", "responsive", "css", "media-query"],
+  "split": "public",
+  "prompt": "Create two files: pricing.html and pricing.css. Build a responsive pricing section for a product called \"OpenEval\". The page must include a root element with data-testid=\"pricing\", an h1 containing \"Choose your plan\", and exactly three plan cards each with data-testid=\"plan-card\" and a visible plan name from \"Free\", \"Team\", and \"Enterprise\". Lay the three cards out with CSS grid using three columns on desktop in pricing.css. Add a CSS @media query with a max-width breakpoint (max-width: 640px or narrower) that collapses the grid to a single column (grid-template-columns: 1fr). Do not use external assets, scripts, or network imports.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 16, "timeout_seconds": 240, "permission_mode": "bypassPermissions" },
+  "budget": { "max_turns": 16, "max_cost_usd": 0.6 },
+  "visual": {
+    "kind": "web_ui",
+    "requires_vision_input": false,
+    "expected_artifacts": ["pricing.html", "pricing.css"]
+  },
+  "graders": [
+    { "type": "file_exists", "path": "pricing.html", "weight": 10 },
+    { "type": "file_exists", "path": "pricing.css", "weight": 10 },
+    { "type": "file_contains", "path": "pricing.html", "pattern": "data-testid=[\"']pricing[\"']", "weight": 10 },
+    { "type": "file_contains", "path": "pricing.html", "pattern": "Choose your plan", "weight": 10 },
+    { "type": "exit_code", "command": "node -e \"const fs=require('fs'); const html=fs.readFileSync('pricing.html','utf8'); const n=(html.match(/data-testid=['\\\"]plan-card['\\\"]/g)||[]).length; if(n!==3) process.exit(1)\"", "weight": 15 },
+    { "type": "file_contains", "path": "pricing.html", "pattern": "Free", "weight": 5 },
+    { "type": "file_contains", "path": "pricing.html", "pattern": "Team", "weight": 5 },
+    { "type": "file_contains", "path": "pricing.html", "pattern": "Enterprise", "weight": 5 },
+    { "type": "file_contains", "path": "pricing.css", "pattern": "grid-template-columns\\s*:[^;]*(1fr[^;]*){3}|repeat\\(\\s*3", "weight": 10 },
+    { "type": "file_contains", "path": "pricing.css", "pattern": "@media[^{]*max-width\\s*:\\s*(640|6[0-3][0-9]|[1-5][0-9][0-9])px", "weight": 15 },
+    { "type": "exit_code", "command": "node -e \"const fs=require('fs'); const css=fs.readFileSync('pricing.css','utf8'); const m=css.match(/@media[^{]*max-width[^{]*\\{[\\s\\S]*?grid-template-columns\\s*:\\s*1fr\\s*;?[\\s\\S]*?\\}/); if(!m) process.exit(1)\"", "weight": 10 },
+    { "type": "file_contains", "path": "pricing.html", "pattern": "https?://(?!www\\.w3\\.org/)|<script", "negate": true, "weight": 10, "forbidden": true }
+  ],
+  "pass_threshold": 0.85,
+  "oracle": {
+    "solve": "oracle/visual-responsive-pricing-grid.sh",
+    "noop_max_score": 0.1,
+    "known_bad": ["oracle/visual-responsive-pricing-grid-bad.sh"]
+  }
+}

--- a/cases/visual-code/visual-sortable-results-table.case.json
+++ b/cases/visual-code/visual-sortable-results-table.case.json
@@ -1,0 +1,40 @@
+{
+  "id": "visual-sortable-results-table",
+  "category": "visual-code",
+  "difficulty": "hard",
+  "name": "Build a client-side sortable results table",
+  "description": "Visual-code task: produce a static, self-contained HTML page with a semantic data table whose columns sort on header click via inline JavaScript. Grading stays deterministic by asserting the table markup, sortable header affordances, aria-sort state, and a click-driven sort handler in the produced artifact.",
+  "tags": ["visual-code", "web-ui", "table", "sorting", "interactive"],
+  "split": "public",
+  "prompt": "Create a single self-contained file named results-table.html (inline <style> and <script> only, no external assets or network imports). Build a sortable results table for OpenEval cases. Requirements: a root element with data-testid=\"results-table\", an h1 containing \"Case Results\", and a <table> with a <thead> whose header cells (<th>) carry data-sort-key attributes for the columns \"case\", \"score\", and \"status\". Each sortable <th> must have a scope=\"col\" attribute and an aria-sort attribute (initially \"none\"). Include a <tbody> with at least three <tr> data rows. Add inline JavaScript that attaches a click handler to the header cells which sorts the tbody rows by the clicked column and updates aria-sort to \"ascending\" or \"descending\". Do not create any other files.",
+  "setup": { "type": "none" },
+  "runner": { "max_turns": 18, "timeout_seconds": 240, "permission_mode": "bypassPermissions" },
+  "budget": { "max_turns": 18, "max_cost_usd": 0.75 },
+  "visual": {
+    "kind": "web_ui",
+    "requires_vision_input": false,
+    "expected_artifacts": ["results-table.html"]
+  },
+  "graders": [
+    { "type": "file_exists", "path": "results-table.html", "weight": 10 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "data-testid=[\"']results-table[\"']", "weight": 10 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "Case Results", "weight": 10 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "<thead\\b", "weight": 5 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "<tbody\\b", "weight": 5 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "data-sort-key=[\"']case[\"']", "weight": 5 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "data-sort-key=[\"']score[\"']", "weight": 5 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "data-sort-key=[\"']status[\"']", "weight": 5 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "scope=[\"']col[\"']", "weight": 10 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "aria-sort=[\"'](none|ascending|descending)[\"']", "weight": 10 },
+    { "type": "exit_code", "command": "node -e \"const fs=require('fs'); const h=fs.readFileSync('results-table.html','utf8'); const rows=(h.match(/<tr\\b/g)||[]).length; if(rows<4) process.exit(1)\"", "weight": 10 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "addEventListener\\s*\\(\\s*[\"']click[\"']|onclick", "weight": 10 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "aria-sort", "weight": 5 },
+    { "type": "file_contains", "path": "results-table.html", "pattern": "https?://(?!www\\.w3\\.org/)|src=[\"']http", "negate": true, "weight": 5, "forbidden": true }
+  ],
+  "pass_threshold": 0.85,
+  "oracle": {
+    "solve": "oracle/visual-sortable-results-table.sh",
+    "noop_max_score": 0.1,
+    "known_bad": ["oracle/visual-sortable-results-table-bad.sh"]
+  }
+}


### PR DESCRIPTION
## Summary

Expands `visual-code` — the thinnest category (2 cases) — to 5 by adding 3 new deterministically-graded cases. **Additive only**: no existing cases or `lib/` touched.

| id | artifact | what it grades |
|----|----------|----------------|
| `visual-mermaid-pipeline-diagram` | `pipeline.mmd` | flowchart header, directed node chain (SelectCases→RunLoop→Executor→Grade→Persist), a labeled known-bad rejection edge |
| `visual-responsive-pricing-grid` | `pricing.html` + `pricing.css` | 3 plan cards, 3-column desktop grid, a real `@media (max-width)` breakpoint collapsing to `1fr` |
| `visual-sortable-results-table` | `results-table.html` | table markup, `data-sort-key` headers, `scope`/`aria-sort` affordances, click-driven sort handler |

Each case follows the existing visual-code pattern: a `visual` block (`requires_vision_input: false`, `expected_artifacts`), deterministic graders over the produced artifact (a deterministic backstop), a `forbidden` negate guard, `pass_threshold` 0.85, and a full `oracle` with `solve` + `known_bad`.

## Verification

- `npm run typecheck` — clean
- `node --import tsx --test tests/cases-schema.test.ts` — 7/7 pass (new cases load via strict loader, ids unique)
- `npm run audit:accuracy` — no new weaknesses (each case has oracle + known_bad + deterministic grader)
- **Oracle proof harness** (ran each solve/known_bad through the real graders):
  - `visual-mermaid-pipeline-diagram`: solve ratio **1.000** (pass), known_bad **0.750** (rejected)
  - `visual-responsive-pricing-grid`: solve ratio **1.000** (pass), known_bad **0.783** (rejected)
  - `visual-sortable-results-table`: solve ratio **1.000** (pass), known_bad **0.524** (rejected)

Each `known_bad` is a plausibly-wrong artifact the graders reject: a diagram missing edges, a fixed grid with no media query, and a static table with no sort affordances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)