### PR TITLE
Harden run loop: log manifest failures, contain throwing status write in fatal catch

### DIFF
--- a/lib/run.ts
+++ b/lib/run.ts
@@ -62,17 +62,58 @@ export async function createAndStartRun(params: CreateRunParams): Promise<{ id: 
     summary: null,
   };
   insertRun(run);
+  // Fire-and-forget: the manifest is best-effort metadata, but a late-resolving
+  // write must not swallow its failure silently, nor land against a run row that
+  // has already gone terminal (the loop finished / was aborted while
+  // collectRunManifest was still probing). writeRunManifestIfLive guards both.
   void collectRunManifest(harness, model, { harnessWasDefault: !params.harness, modelWasDefault: !params.model, modelDefaultSource: resolvedDefault.source })
-    .then((m) => updateRunManifest(id, m))
-    .catch(() => {});
+    .then((m) => writeRunManifestIfLive(id, m))
+    .catch((e) => {
+      console.error(`[run ${id}] manifest collection/update failed:`, e?.stack || e);
+    });
   appendEvent(id, "run_started", { case_count: cases.length, samples, runner: params.runner, harness, model }, undefined);
 
-  void runLoop(id, cases, params.runner, harness, params.parallel, model, samples).catch((e) => {
-    appendEvent(id, "run_fatal", { error: String(e?.stack || e) }, undefined);
-    updateRunStatus(id, "failed", Date.now(), null);
-  });
+  void runLoop(id, cases, params.runner, harness, params.parallel, model, samples).catch((e) => finalizeFailedRun(id, e));
 
   return { id, caseCount: cases.length * samples };
+}
+
+/**
+ * Best-effort manifest write that no-ops once the run row is terminal. A late
+ * `collectRunManifest` resolution must not clobber (or race a teardown of) a run
+ * that already completed/aborted/failed while the harness probes were in flight.
+ * Exported for the run-lifecycle regression tests.
+ */
+export function writeRunManifestIfLive(id: string, manifest: unknown): void {
+  let status: string | undefined;
+  try {
+    status = getRunStatus(id) ?? undefined;
+  } catch {
+    status = undefined;
+  }
+  if (status && status !== "running") return; // run already torn down — no-op
+  updateRunManifest(id, manifest);
+}
+
+/**
+ * Top-level handler for a rejected `runLoop`. `updateRunStatus` can itself throw
+ * (e.g. a DB error) — and because this runs inside the `.catch` of a fire-and-
+ * forget promise, a throw here escapes as an unhandled rejection that can crash
+ * the dev server. Contain the status write in its own try/catch so the failure
+ * is logged, not fatal. Exported for the run-lifecycle regression tests.
+ */
+export function finalizeFailedRun(id: string, e: unknown): void {
+  const err = e as { stack?: string } | undefined;
+  try {
+    appendEvent(id, "run_fatal", { error: String(err?.stack || e) }, undefined);
+  } catch (evtErr) {
+    console.error(`[run ${id}] failed to append run_fatal event:`, (evtErr as { stack?: string })?.stack || evtErr);
+  }
+  try {
+    updateRunStatus(id, "failed", Date.now(), null);
+  } catch (statusErr) {
+    console.error(`[run ${id}] failed to mark run failed after fatal error:`, (statusErr as { stack?: string })?.stack || statusErr);
+  }
 }
 
 async function runLoop(runId: string, cases: CaseDefinition[], runner: RunnerKind, harness: string, parallel: number, model?: string, samples = 1) {

--- a/tests/run-lifecycle.test.ts
+++ b/tests/run-lifecycle.test.ts
@@ -141,3 +141,79 @@ test("cancel seam: an aborted run row is visible through the DB check the loop u
   db.updateRunStatus(runId, "aborted", Date.now(), null);
   assert.equal(db.getRun(runId)?.status, "aborted");
 });
+
+// --- run.ts hardening: fire-and-forget manifest + fatal-catch resilience ---
+
+test("writeRunManifestIfLive writes the manifest while the run is still running", async () => {
+  const { writeRunManifestIfLive } = await import("../lib/run");
+  const db = await import("../lib/db");
+  const runId = "manifest-live-run";
+  db.insertRun(runRecord(runId, "running", Date.now()));
+  writeRunManifestIfLive(runId, { probed: true });
+  assert.deepEqual(db.getRun(runId)?.manifest, { probed: true });
+  db.updateRunStatus(runId, "aborted", Date.now(), null);
+});
+
+test("writeRunManifestIfLive no-ops once the run row is terminal (late manifest can't clobber)", async () => {
+  const { writeRunManifestIfLive } = await import("../lib/run");
+  const db = await import("../lib/db");
+  const runId = "manifest-late-run";
+  // Run already finished/aborted while collectRunManifest was still probing.
+  db.insertRun(runRecord(runId, "completed", Date.now()));
+  writeRunManifestIfLive(runId, { late: true });
+  assert.equal(db.getRun(runId)?.manifest, undefined, "a late manifest write must not land on a terminal run");
+});
+
+// Regression: the top-level runLoop(...).catch invokes updateRunStatus, which
+// can itself throw (DB error). Before the fix that throw escaped the .catch of
+// a fire-and-forget promise as an unhandled rejection. finalizeFailedRun must
+// contain it. We induce a real DB error by renaming the `runs` table aside
+// (updateRunStatus then fails to prepare) while the events table stays intact,
+// and always restore it.
+test("finalizeFailedRun contains a throwing updateRunStatus and still records run_fatal", async () => {
+  const { finalizeFailedRun } = await import("../lib/run");
+  const db = await import("../lib/db");
+  const runId = "fatal-sync-run";
+  db.insertRun(runRecord(runId, "running", Date.now()));
+  const raw = db.getDb();
+
+  let threw = false;
+  raw.exec("ALTER TABLE runs RENAME TO runs_bak_fatal_sync");
+  try {
+    finalizeFailedRun(runId, new Error("loop blew up"));
+  } catch {
+    threw = true; // without the try/catch around updateRunStatus this is reached
+  } finally {
+    raw.exec("ALTER TABLE runs_bak_fatal_sync RENAME TO runs");
+  }
+
+  assert.equal(threw, false, "finalizeFailedRun must swallow a throwing updateRunStatus");
+  const kinds = db.listEvents(runId).map((e) => e.kind);
+  assert.ok(kinds.includes("run_fatal"), "run_fatal event is recorded even when the status write fails");
+  db.updateRunStatus(runId, "failed", Date.now(), null);
+});
+
+test("a rejected runLoop whose status write throws produces no unhandled rejection", async () => {
+  const { finalizeFailedRun } = await import("../lib/run");
+  const db = await import("../lib/db");
+  const runId = "fatal-async-run";
+  db.insertRun(runRecord(runId, "running", Date.now()));
+  const raw = db.getDb();
+
+  const seen: unknown[] = [];
+  const onUnhandled = (reason: unknown) => seen.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  raw.exec("ALTER TABLE runs RENAME TO runs_bak_fatal_async");
+  try {
+    // Exact production shape: a fire-and-forget promise whose .catch runs the
+    // finalizer, which internally hits a throwing updateRunStatus.
+    void Promise.reject(new Error("loop blew up")).catch((e) => finalizeFailedRun(runId, e));
+    await new Promise((r) => setTimeout(r, 25));
+  } finally {
+    raw.exec("ALTER TABLE runs_bak_fatal_async RENAME TO runs");
+    process.removeListener("unhandledRejection", onUnhandled);
+  }
+
+  assert.deepEqual(seen, [], "no unhandled rejection escaped the fatal-run finalizer");
+  db.updateRunStatus(runId, "failed", Date.now(), null);
+});


### PR DESCRIPTION
## Summary

Two stability fixes in `lib/run.ts`, both in `createAndStartRun`'s fire-and-forget promise handlers.

1. **Manifest write** — the old `.then(updateRunManifest).catch(() => {})` swallowed every failure silently and could land a late-resolving write against a run row that had already gone terminal (loop finished/aborted while `collectRunManifest` was still probing harnesses). Extracted to `writeRunManifestIfLive`: failures are now logged with run context, and the write no-ops once the run status is no longer `running`.

2. **Fatal catch** — the top-level `runLoop(...).catch(...)` invoked `updateRunStatus`, which can itself throw (DB error). Inside the `.catch` of a `void` promise, that throw escaped as an unhandled rejection able to crash the dev server. Extracted to `finalizeFailedRun`: the status write and the `run_fatal` event append are each contained in their own try/catch and logged on failure.

Both handlers were extracted to small exported functions so the regression tests can drive the exact failure paths without spinning up a non-hermetic full run.

## Tests

Extended `tests/run-lifecycle.test.ts`:
- `finalizeFailedRun` swallows a throwing `updateRunStatus` and still records `run_fatal` (a real DB error is induced by renaming the `runs` table aside, so `updateRunStatus` fails to prepare while the events table stays writable; always restored).
- No unhandled rejection escapes the production `void Promise.reject(...).catch(finalize)` shape.
- `writeRunManifestIfLive` writes while running and no-ops once terminal.

The two fatal-path tests fail without the fix (verified: `# pass 8 # fail 2`).

`npm run typecheck`, `node --import tsx --test tests/run-lifecycle.test.ts` (10/10), and `npm run selftest` (26 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)