### PR TITLE
evals: add Python (pytest) median bugfix case for cross-language breadth

### DIFF
--- a/cases/agentic-swe/oracle/swe-py-fix-median-bad.sh
+++ b/cases/agentic-swe/oracle/swe-py-fix-median-bad.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Known-bad: an off-by-one "fix" that returns the lower-middle element for
+# even-length lists. Still wrong (median([1,2,3,4]) -> 2, not 2.5) so the
+# graders must reject it.
+cat > stats.py <<'PY'
+"""Small statistics helpers."""
+
+
+def median(nums):
+    s = sorted(nums)
+    return s[len(s) // 2 - 1]
+PY

--- a/cases/agentic-swe/oracle/swe-py-fix-median.sh
+++ b/cases/agentic-swe/oracle/swe-py-fix-median.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+cat > stats.py <<'PY'
+"""Small statistics helpers."""
+
+
+def median(nums):
+    """Return the median of a non-empty list of numbers."""
+    s = sorted(nums)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 1:
+        return s[mid]
+    return (s[mid - 1] + s[mid]) / 2
+PY

--- a/cases/agentic-swe/swe-py-fix-median.case.json
+++ b/cases/agentic-swe/swe-py-fix-median.case.json
@@ -1,0 +1,55 @@
+{
+  "id": "swe-py-fix-median",
+  "difficulty": "medium",
+  "category": "agentic-swe",
+  "name": "Fix Python median for even-length lists",
+  "description": "A Python median() helper returns the wrong value for even-length inputs: it yields the upper-middle element instead of averaging the two middle elements. Fix the implementation so the pytest suite passes.",
+  "tags": [
+    "bugfix",
+    "python",
+    "pytest",
+    "tests"
+  ],
+  "prompt": "stats.py implements median(nums) but it is wrong for even-length lists: median([1, 2, 3, 4]) should be 2.5 (the average of 2 and 3), not 3. Fix the implementation so it returns the true statistical median for both odd- and even-length inputs. Run `python3 -m pytest -q` to verify all tests pass. Do not modify test_stats.py.",
+  "setup": {
+    "type": "fixture",
+    "fixture": "py-median-stats",
+    "init_git": true
+  },
+  "runner": {
+    "max_turns": 18,
+    "timeout_seconds": 240,
+    "permission_mode": "bypassPermissions"
+  },
+  "graders": [
+    {
+      "type": "tests_pass",
+      "command": "python3 -m pytest -q",
+      "timeout_ms": 30000
+    },
+    {
+      "type": "exit_code",
+      "command": "python3 -c \"from stats import median; assert median([1,2,3])==2; assert median([1,2,3,4])==2.5; assert median([7,1,3,5])==4.0; assert median([5])==5\""
+    },
+    {
+      "type": "file_contains",
+      "path": "stats.py",
+      "pattern": "% 2|- 1|& 1"
+    },
+    {
+      "type": "files_unchanged",
+      "paths": [
+        "test_stats.py"
+      ],
+      "forbidden": true
+    }
+  ],
+  "pass_threshold": 1,
+  "oracle": {
+    "solve": "oracle/swe-py-fix-median.sh",
+    "known_bad": [
+      "oracle/swe-py-fix-median-bad.sh"
+    ],
+    "noop_max_score": 0.25
+  }
+}

--- a/fixtures/py-median-stats/stats.py
+++ b/fixtures/py-median-stats/stats.py
@@ -1,0 +1,11 @@
+"""Small statistics helpers."""
+
+
+def median(nums):
+    """Return the median of a non-empty list of numbers.
+
+    BUG: for even-length inputs this returns the upper-middle element
+    instead of the average of the two middle elements.
+    """
+    s = sorted(nums)
+    return s[len(s) // 2]

--- a/fixtures/py-median-stats/test_stats.py
+++ b/fixtures/py-median-stats/test_stats.py
@@ -1,0 +1,16 @@
+from stats import median
+
+
+def test_median_odd_length():
+    assert median([1, 2, 3]) == 2
+    assert median([5]) == 5
+
+
+def test_median_even_length():
+    assert median([1, 2, 3, 4]) == 2.5
+    assert median([7, 1, 3, 5]) == 4.0
+
+
+def test_median_unsorted_input():
+    assert median([3, 1, 2]) == 2
+    assert median([10, 2, 8, 4]) == 6.0


### PR DESCRIPTION
## What

Adds one new agentic-swe case, `swe-py-fix-median`, plus a new `fixtures/py-median-stats` fixture. Every existing agentic-swe fixture is Node/JS, so the suite only measured JS competence; this adds Python (pytest) breadth. **New files only — no existing cases/fixtures/lib touched.**

## The bug under test

`stats.py` implements `median(nums)` that returns the upper-middle element for even-length lists (`median([1,2,3,4])` yields `3` instead of `2.5`). The agent must fix it so both odd- and even-length inputs return the true median.

## Graders

- `tests_pass` — `python3 -m pytest -q` (the `tests_pass` grader parses pytest's "N passed"/"N failed" summary and honors `min_passed`)
- `exit_code` — independent Python assertions of median values (deterministic backstop that does not depend on the test file)
- `file_contains` — confirms the fix touches parity/average logic
- `files_unchanged` (forbidden) — guards `test_stats.py` against tampering

## Oracle

- `oracle.solve` — correct odd/even median implementation
- `oracle.known_bad` — an off-by-one "fix" (returns lower-middle element) that leaves tests failing, so the case correctly rejects a wrong answer
- `noop_max_score: 0.25`

## Verification

- `npm run typecheck` clean
- `tests/cases-schema.test.ts` — 7/7 pass (new case validates)
- `npm run selftest` — 28 pass, 0 fail: oracle solve passes all graders, known_bad rejected (0.50), no-op baseline 0.25
- `npm run audit:accuracy` — new case is **not** weak (has oracle + known_bad + deterministic grader)
- Manually confirmed against a temp copy: buggy baseline fails pytest (2 failed), solve passes (3 passed), known_bad fails (3 failed). `python3`/`pytest 9.1.0` verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)