### PR TITLE
evals: harden accuracy audit (on-disk oracle check, no-op/weak-backstop heuristics, --strict-known-bad)

### DIFF
--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -1,4 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CASES_DIR } from "./config";
 import type { CaseDefinition, EvidenceTier, GraderSpec } from "./types";
+
+/**
+ * Options for filesystem-aware audit checks. Injectable so unit tests can point
+ * at a synthetic corpus / resolver without touching the real cases directory.
+ */
+export interface AuditOptions {
+  /** Directory that oracle script paths (`oracle/foo.sh`) resolve against, per category. Defaults to {@link CASES_DIR}. */
+  casesDir?: string;
+  /** Existence predicate for a resolved absolute path. Defaults to {@link fs.existsSync}. */
+  fileExists?: (absPath: string) => boolean;
+}
 
 export interface CaseAccuracyAudit {
   id: string;
@@ -70,8 +84,30 @@ export function evidenceLabel(tier: EvidenceTier): string {
   }
 }
 
-export function auditCases(cases: CaseDefinition[]): AccuracyAudit {
-  const rows = cases.map((c) => auditCase(c));
+/**
+ * True when a do-nothing ("no-op") agent — empty final text, no file changes,
+ * no tool calls — would still PASS this grader. Such graders provide no signal
+ * that the agent actually solved the task; a case whose deterministic graders
+ * are all no-op-passing can score high on an empty run unless `noop_max_score`
+ * catches it during selftest.
+ */
+function noopPassesGrader(spec: GraderSpec): boolean {
+  switch (spec.type) {
+    case "files_unchanged":
+      return true;
+    case "file_exists":
+    case "file_contains":
+    case "regex_match":
+    case "git_diff_contains":
+    case "step":
+      return spec.negate === true;
+    default:
+      return false;
+  }
+}
+
+export function auditCases(cases: CaseDefinition[], opts?: AuditOptions): AccuracyAudit {
+  const rows = cases.map((c) => auditCase(c, opts));
   const tierTotals = { ...EMPTY_TIERS };
   for (const row of rows) {
     for (const [tier, count] of Object.entries(row.tiers) as Array<[EvidenceTier, number]>) {
@@ -91,7 +127,10 @@ export function auditCases(cases: CaseDefinition[]): AccuracyAudit {
   };
 }
 
-function auditCase(c: CaseDefinition): CaseAccuracyAudit {
+export function auditCase(c: CaseDefinition, opts?: AuditOptions): CaseAccuracyAudit {
+  const casesDir = opts?.casesDir ?? CASES_DIR;
+  const fileExists = opts?.fileExists ?? fs.existsSync;
+
   const tiers = { ...EMPTY_TIERS };
   for (const grader of c.graders) tiers[graderEvidenceTier(grader)]++;
   if (c.visual?.expected_artifacts?.length) tiers.visual++;
@@ -106,6 +145,38 @@ function auditCase(c: CaseDefinition): CaseAccuracyAudit {
   if (!hasDeterministic) weaknesses.push("no deterministic or trace grader");
   if (tiers.llm_judge > 0 && tiers.deterministic === 0) weaknesses.push("LLM judge without deterministic backstop");
   if (c.visual?.requires_vision_input && !c.visual.expected_artifacts?.length) weaknesses.push("vision-input task has no visual artifact contract");
+
+  // Oracle-file existence: `solve` / `known_bad` are script paths resolved as
+  // <casesDir>/<category>/<path> (mirrors selftest.ts). A declared-but-missing
+  // script silently disables selftest coverage, so flag it as a real weakness.
+  const oracleScripts: string[] = [];
+  if (c.oracle?.solve) oracleScripts.push(c.oracle.solve);
+  for (const kb of c.oracle?.known_bad ?? []) oracleScripts.push(kb);
+  for (const rel of oracleScripts) {
+    const abs = path.join(casesDir, c.category, rel);
+    if (!fileExists(abs)) weaknesses.push(`oracle script missing on disk: ${rel}`);
+  }
+
+  // No-op baseline: if every deterministic grader passes on a do-nothing run and
+  // there is no `noop_max_score` guard, an empty submission could score high and
+  // go undetected. Reported (not a hard failure).
+  const deterministicGraders = c.graders.filter((g) => graderEvidenceTier(g) === "deterministic");
+  const hasNoopGuard = typeof c.oracle?.noop_max_score === "number";
+  if (deterministicGraders.length > 0 && deterministicGraders.every(noopPassesGrader) && !hasNoopGuard) {
+    weaknesses.push("deterministic graders all pass on a no-op run; no oracle.noop_max_score guard");
+  }
+
+  // Weak backstop: an LLM-judge case satisfies "has a deterministic backstop"
+  // (rule above) even if that backstop is only broad regex_match graders, which
+  // can rubber-stamp any output. Flag when regex_match is the sole deterministic
+  // teeth behind a rubric_llm grader.
+  if (
+    tiers.llm_judge > 0 &&
+    deterministicGraders.length > 0 &&
+    deterministicGraders.every((g) => g.type === "regex_match")
+  ) {
+    weaknesses.push("rubric_llm backstop is only regex_match graders (weak deterministic teeth)");
+  }
 
   return {
     id: c.id,

--- a/lib/cli/accuracy.ts
+++ b/lib/cli/accuracy.ts
@@ -2,7 +2,26 @@
 import { auditCases, evidenceLabel } from "../accuracy";
 import { loadCases } from "../cases";
 
+const HELP = `Usage: tsx lib/cli/accuracy.ts [options]
+
+Audits the case corpus for grader-accuracy weaknesses (missing oracle, no
+known-bad rejection, no deterministic backstop, no-op-passable graders, weak
+regex-only backstops behind an LLM judge, missing oracle scripts on disk).
+
+Options:
+  --strict            Exit nonzero if any case lacks an oracle or a
+                      deterministic/trace grader. (unchanged)
+  --strict-known-bad  Additionally exit nonzero if any case lacks a known-bad
+                      rejection script. Opt-in; leaves --strict untouched.
+  -h, --help          Show this help.`;
+
 async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes("-h") || argv.includes("--help")) {
+    console.log(HELP);
+    return;
+  }
+
   const cases = await loadCases();
   const audit = auditCases(cases);
 
@@ -26,7 +45,16 @@ async function main() {
   }
 
   const hardFailures = weak.filter((c) => !c.hasOracle || c.tiers.deterministic + c.tiers.trace === 0);
-  if (process.argv.includes("--strict") && hardFailures.length) process.exit(1);
+  if (argv.includes("--strict") && hardFailures.length) process.exit(1);
+
+  // Opt-in: promote the "no known-bad rejection" weakness to a hard failure.
+  // Independent of --strict so existing --strict behavior is unchanged.
+  const knownBadFailures = audit.cases.filter((c) => !c.hasKnownBad);
+  if (argv.includes("--strict-known-bad") && knownBadFailures.length) {
+    console.error(`\n--strict-known-bad: ${knownBadFailures.length} case(s) lack a known-bad rejection script:`);
+    for (const c of knownBadFailures) console.error(`  - ${c.id}`);
+    process.exit(1);
+  }
 }
 
 main().catch((e) => {

--- a/tests/accuracy.test.ts
+++ b/tests/accuracy.test.ts
@@ -1,0 +1,165 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { auditCase, auditCases } from "../lib/accuracy";
+import { loadCases } from "../lib/cases";
+import { REPO_ROOT } from "../lib/config";
+import type { CaseDefinition, GraderSpec } from "../lib/types";
+
+function makeCase(overrides: Partial<CaseDefinition> = {}): CaseDefinition {
+  return {
+    id: "synthetic",
+    category: "single-tool",
+    name: "Synthetic",
+    prompt: "do a thing",
+    graders: [{ type: "exit_code", command: "true" }] as GraderSpec[],
+    ...overrides,
+  };
+}
+
+// A fileExists that only knows about paths we explicitly register as present.
+function existsOnly(present: string[]): (p: string) => boolean {
+  const set = new Set(present.map((p) => path.normalize(p)));
+  return (p: string) => set.has(path.normalize(p));
+}
+
+test("oracle-file existence: fires on a dangling solve script", () => {
+  const c = makeCase({ oracle: { solve: "oracle/does-not-exist.sh" } });
+  const row = auditCase(c, { casesDir: "/tmp/synthetic-cases", fileExists: () => false });
+  assert.ok(
+    row.weaknesses.some((w) => w.startsWith("oracle script missing on disk: oracle/does-not-exist.sh")),
+    `expected missing-script weakness, got: ${JSON.stringify(row.weaknesses)}`,
+  );
+});
+
+test("oracle-file existence: fires on a dangling known_bad script but not the present solve", () => {
+  const casesDir = "/tmp/synthetic-cases";
+  const solveAbs = path.join(casesDir, "single-tool", "oracle/solve.sh");
+  const c = makeCase({
+    oracle: { solve: "oracle/solve.sh", known_bad: ["oracle/bad-missing.sh"] },
+  });
+  const row = auditCase(c, { casesDir, fileExists: existsOnly([solveAbs]) });
+  const missing = row.weaknesses.filter((w) => w.startsWith("oracle script missing on disk"));
+  assert.equal(missing.length, 1, `exactly the missing known_bad should flag, got: ${JSON.stringify(missing)}`);
+  assert.ok(missing[0].includes("oracle/bad-missing.sh"));
+});
+
+test("oracle-file existence: silent when all referenced scripts resolve", () => {
+  const casesDir = "/tmp/synthetic-cases";
+  const solveAbs = path.join(casesDir, "single-tool", "oracle/solve.sh");
+  const badAbs = path.join(casesDir, "single-tool", "oracle/bad.sh");
+  const c = makeCase({ oracle: { solve: "oracle/solve.sh", known_bad: ["oracle/bad.sh"] } });
+  const row = auditCase(c, { casesDir, fileExists: existsOnly([solveAbs, badAbs]) });
+  assert.equal(
+    row.weaknesses.filter((w) => w.startsWith("oracle script missing on disk")).length,
+    0,
+  );
+});
+
+test("no-op baseline heuristic: fires when all deterministic graders no-op-pass and no guard", () => {
+  const c = makeCase({
+    oracle: { solve: "oracle/solve.sh" }, // no noop_max_score
+    graders: [
+      { type: "files_unchanged", paths: ["a.txt"] },
+      { type: "file_exists", path: "out.txt", negate: true },
+    ] as GraderSpec[],
+  });
+  const row = auditCase(c, { fileExists: () => true });
+  assert.ok(row.weaknesses.some((w) => w.includes("no-op run")), JSON.stringify(row.weaknesses));
+});
+
+test("no-op baseline heuristic: silent when noop_max_score guard is present", () => {
+  const c = makeCase({
+    oracle: { solve: "oracle/solve.sh", noop_max_score: 0.2 },
+    graders: [{ type: "files_unchanged", paths: ["a.txt"] }] as GraderSpec[],
+  });
+  const row = auditCase(c, { fileExists: () => true });
+  assert.ok(!row.weaknesses.some((w) => w.includes("no-op run")), JSON.stringify(row.weaknesses));
+});
+
+test("no-op baseline heuristic: silent when a positive deterministic grader has teeth", () => {
+  const c = makeCase({
+    oracle: { solve: "oracle/solve.sh" },
+    graders: [
+      { type: "files_unchanged", paths: ["a.txt"] },
+      { type: "file_contains", path: "out.txt", pattern: "hello" }, // positive assertion, no-op fails it
+    ] as GraderSpec[],
+  });
+  const row = auditCase(c, { fileExists: () => true });
+  assert.ok(!row.weaknesses.some((w) => w.includes("no-op run")), JSON.stringify(row.weaknesses));
+});
+
+test("weak-backstop heuristic: fires for rubric_llm whose only deterministic graders are regex_match", () => {
+  const c = makeCase({
+    oracle: { solve: "oracle/solve.sh", known_bad: ["oracle/bad.sh"] },
+    graders: [
+      { type: "rubric_llm", rubric: "is it good?" },
+      { type: "regex_match", pattern: "answer", source: "final_text" },
+    ] as GraderSpec[],
+  });
+  const row = auditCase(c, { fileExists: () => true });
+  assert.ok(
+    row.weaknesses.some((w) => w.includes("only regex_match")),
+    JSON.stringify(row.weaknesses),
+  );
+});
+
+test("weak-backstop heuristic: silent when a non-regex deterministic grader backs the judge", () => {
+  const c = makeCase({
+    oracle: { solve: "oracle/solve.sh", known_bad: ["oracle/bad.sh"] },
+    graders: [
+      { type: "rubric_llm", rubric: "is it good?" },
+      { type: "file_contains", path: "out.txt", pattern: "answer" },
+    ] as GraderSpec[],
+  });
+  const row = auditCase(c, { fileExists: () => true });
+  assert.ok(!row.weaknesses.some((w) => w.includes("only regex_match")), JSON.stringify(row.weaknesses));
+});
+
+test("auditCases forwards options to every row", () => {
+  const cases = [makeCase({ id: "a", oracle: { solve: "oracle/missing.sh" } })];
+  const audit = auditCases(cases, { fileExists: () => false });
+  assert.ok(audit.cases[0].weaknesses.some((w) => w.startsWith("oracle script missing on disk")));
+});
+
+// --- CLI-level guarantees on the REAL corpus ---
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("node", ["--import", "tsx", "lib/cli/accuracy.ts", ...args], {
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (e: any) {
+    return { status: e.status ?? 1, stdout: e.stdout?.toString() ?? "", stderr: e.stderr?.toString() ?? "" };
+  }
+}
+
+test("current corpus has no dangling oracle scripts", async () => {
+  const cases = await loadCases();
+  const audit = auditCases(cases);
+  const dangling = audit.cases.flatMap((c) =>
+    c.weaknesses.filter((w) => w.startsWith("oracle script missing on disk")).map((w) => `${c.id}: ${w}`),
+  );
+  assert.deepEqual(dangling, [], `unexpected dangling oracle scripts: ${JSON.stringify(dangling)}`);
+});
+
+test("--strict still exits 0 on the current corpus (no regression)", () => {
+  const { status } = runCli(["--strict"]);
+  assert.equal(status, 0);
+});
+
+test("--strict-known-bad exits nonzero on the current corpus (13 cases lack known-bad)", () => {
+  const { status, stderr } = runCli(["--strict-known-bad"]);
+  assert.equal(status, 1);
+  assert.match(stderr, /lack a known-bad rejection script/);
+});
+
+test("--help exits 0 and documents --strict-known-bad", () => {
+  const { status, stdout } = runCli(["--help"]);
+  assert.equal(status, 0);
+  assert.match(stdout, /--strict-known-bad/);
+});


### PR DESCRIPTION
## Summary

Makes `lib/accuracy.ts` / `lib/cli/accuracy.ts` a meaningfully stronger audit **without changing** the default `npm run audit:accuracy` output or the existing `--strict` exit behavior (so concurrent batch units adding known-bad scripts can still merge independently).

### New checks in `auditCase`
1. **Oracle-file existence** — flags a weakness when a referenced `oracle.solve` / `known_bad` script path does not resolve on disk. Resolution mirrors `selftest.ts`: `<casesDir>/<category>/<path>`. A new `AuditOptions` ({ `casesDir`, `fileExists` }) makes it injectable/testable; defaults to `CASES_DIR` + `fs.existsSync`. All 23 referenced scripts in the current corpus resolve, so it does not fire today.
2. **No-op baseline heuristic** — reported weakness when every deterministic grader would pass on a do-nothing run and there is no `oracle.noop_max_score` guard (an empty submission could score high undetected).
3. **Weak-backstop heuristic** — reported weakness when a `rubric_llm` case's only deterministic graders are `regex_match` (guards against a rubber-stamp backstop that satisfies "LLM judge needs a deterministic backstop" without real teeth). Fires on 3 reasoning cases.

### CLI
- New **opt-in** `--strict-known-bad` flag promotes the existing "no known-bad rejection" weakness to a nonzero exit. Plain `--strict` is left **exactly** as-is. Documented in `--help`.

### Tests
`tests/accuracy.test.ts` covers: existence check firing on a synthetic dangling-script case (and staying silent when scripts resolve), both heuristics (fire + silent cases), `--strict-known-bad` exits nonzero on the real corpus, and plain `--strict` still exits 0.

## Verification
- `npm run typecheck` clean
- `npm test` green (full suite)
- `npm run audit:accuracy` unchanged; `npm run audit:accuracy:strict` still exits 0
- `tsx lib/cli/accuracy.ts --strict-known-bad` exits 1 (13 cases lack known-bad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)