### PR TITLE
harden-executor: async cancellable git, guarded hot-path DB writes, non-string tool_result

### DIFF
--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -29,24 +29,34 @@ async function loadHarnessInfo(harness: string | undefined, adapterId: string): 
   }
 }
 
-export async function prepareWorkdir(runId: string, caseId: string, def: CaseDefinition, sample: number): Promise<{ dir: string; fixtureSrc?: string }> {
+// git clone/init run through async execFile with a hard timeout and the run's
+// AbortSignal. Synchronous exec here would block the whole event loop — a
+// stalled network clone would freeze every parallel worker, the SSE heartbeat,
+// and the dashboard, and could not be cancelled.
+const GIT_CLONE_TIMEOUT_MS = 120_000;
+const GIT_INIT_TIMEOUT_MS = 30_000;
+
+export async function prepareWorkdir(runId: string, caseId: string, def: CaseDefinition, sample: number, signal?: AbortSignal): Promise<{ dir: string; fixtureSrc?: string }> {
   const dir = path.join(WORKDIRS_DIR, runId, `${caseId}__s${sample}`);
   await fs.mkdir(dir, { recursive: true });
   const setup = def.setup;
   let fixtureSrc: string | undefined;
   if (!setup || setup.type === "none") return { dir };
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execFileAsync = promisify(execFile);
   if (setup.type === "fixture" && setup.fixture) {
     fixtureSrc = path.resolve(FIXTURES_DIR, setup.fixture);
     await copyDir(fixtureSrc, dir);
   } else if (setup.type === "git-clone" && setup.repo) {
-    const { execFileSync } = await import("node:child_process");
     // execFile (no shell) so a crafted case-descriptor repo value can't inject shell commands.
-    execFileSync("git", ["clone", "--depth", "1", "--", setup.repo, "."], { cwd: dir, stdio: "pipe" });
+    await execFileAsync("git", ["clone", "--depth", "1", "--", setup.repo, "."], { cwd: dir, timeout: GIT_CLONE_TIMEOUT_MS, signal });
   }
   if (setup.init_git) {
-    const { execSync } = await import("node:child_process");
     try {
-      execSync("git init -q && git add -A && git -c user.email=eval@local -c user.name=eval commit -q -m baseline", { cwd: dir, stdio: "pipe" });
+      await execFileAsync("git", ["init", "-q"], { cwd: dir, timeout: GIT_INIT_TIMEOUT_MS, signal });
+      await execFileAsync("git", ["add", "-A"], { cwd: dir, timeout: GIT_INIT_TIMEOUT_MS, signal });
+      await execFileAsync("git", ["-c", "user.email=eval@local", "-c", "user.name=eval", "commit", "-q", "-m", "baseline"], { cwd: dir, timeout: GIT_INIT_TIMEOUT_MS, signal });
     } catch {}
   }
   return { dir, fixtureSrc };
@@ -97,7 +107,16 @@ async function resolveInputImages(def: CaseDefinition, workdir: string): Promise
   return images;
 }
 
-function transcriptToText(r: RunnerResult): string {
+function safeJsonStringify(v: unknown): string {
+  try {
+    const s = JSON.stringify(v);
+    return typeof s === "string" ? s : String(v);
+  } catch {
+    return String(v);
+  }
+}
+
+export function transcriptToText(r: RunnerResult): string {
   const lines: string[] = [];
   for (const m of r.transcript) {
     if (m.role === "assistant") {
@@ -107,7 +126,13 @@ function transcriptToText(r: RunnerResult): string {
       }
     } else if (m.role === "user") {
       for (const b of m.content) {
-        if (b.type === "tool_result") lines.push(`TOOL_RESULT(${b.tool_use_id}): ${b.content.slice(0, 2000)}`);
+        if (b.type === "tool_result") {
+          // b.content is typed as string, but a real harness can emit a
+          // structured content block (array/object). Coerce so a non-string
+          // never throws and turns a gradeable run into a spurious error.
+          const raw = typeof b.content === "string" ? b.content : safeJsonStringify(b.content);
+          lines.push(`TOOL_RESULT(${b.tool_use_id}): ${raw.slice(0, 2000)}`);
+        }
       }
     }
   }
@@ -128,7 +153,7 @@ export async function executeCase(
   let workdir: string;
   let fixtureSrc: string | undefined;
   try {
-    ({ dir: workdir, fixtureSrc } = await prepareWorkdir(runId, def.id, def, sample));
+    ({ dir: workdir, fixtureSrc } = await prepareWorkdir(runId, def.id, def, sample, signal));
   } catch (e: any) {
     // Workdir prep (fixture copy / git clone) failed. Record this case as
     // errored so it still counts in the summary and one bad case cannot abort
@@ -221,9 +246,17 @@ export async function executeCase(
         .catch((e: any) => {
           if (!transcriptState.error) transcriptState.error = String(e?.message || e);
         });
-      if (ev.kind === "tool_use") appendEvent(runId, "tool_use", { case_id: def.id, sample, tool: ev.tool, id: ev.id }, def.id);
-      else if (ev.kind === "tool_result") appendEvent(runId, "tool_result", { case_id: def.id, sample, id: ev.id, error: ev.isError }, def.id);
-      else if (ev.kind === "message") appendEvent(runId, "assistant_message", { case_id: def.id, sample, text: (ev.message.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("").slice(0, 200)) }, def.id);
+      // appendEvent is a synchronous SQLite write on the runner's hot path. A
+      // transient SQLITE_BUSY/serialization throw here must not escape and abort
+      // the in-flight case (the sibling transcript append above is guarded too).
+      try {
+        if (ev.kind === "tool_use") appendEvent(runId, "tool_use", { case_id: def.id, sample, tool: ev.tool, id: ev.id }, def.id);
+        else if (ev.kind === "tool_result") appendEvent(runId, "tool_result", { case_id: def.id, sample, id: ev.id, error: ev.isError }, def.id);
+        else if (ev.kind === "message") appendEvent(runId, "assistant_message", { case_id: def.id, sample, text: (ev.message.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("").slice(0, 200)) }, def.id);
+      } catch {
+        // Live-feed events are best-effort telemetry; grading reads from the
+        // settled transcript, not this stream. Swallow, never rethrow.
+      }
     },
   };
 

--- a/tests/executor-edges.test.ts
+++ b/tests/executor-edges.test.ts
@@ -5,7 +5,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import type { CaseDefinition, RunnerContext } from "../lib/types";
+import type { CaseDefinition, RunnerContext, RunnerResult } from "../lib/types";
 
 /**
  * Runner/executor edge hardening (U07):
@@ -279,6 +279,91 @@ test("a genuine agent failure is not masked by a concurrent transcript write fai
   }
   assert.equal(rec.status, "failed", "error-vs-failed precedence: real agent evidence wins");
   assert.match(rec.error_msg ?? "", /Transcript write failed/, "the infrastructure cause is still recorded");
+});
+
+// ---- harden-executor: robustness regressions ----
+
+test("transcriptToText coerces a non-string tool_result content instead of throwing", async () => {
+  // transcriptToText is exported and grades transcripts from ANY source. The
+  // built-in stream-json parser coerces tool_result.content to a string
+  // upstream, but a descriptor/custom adapter (or an externally reconstructed
+  // transcript) can hand it a structured block. The type says `content: string`
+  // yet the unguarded `.slice()` used to throw on a non-string and turn a
+  // gradeable run into a spurious "Grader threw" error.
+  const { transcriptToText } = await import("../lib/executor");
+  const runner = {
+    transcript: [
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "read", input: { path: "a" } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: [{ type: "text", text: "structured" }] as unknown as string }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t2", content: 42 as unknown as string }] },
+    ],
+  } as unknown as RunnerResult;
+
+  let text = "";
+  assert.doesNotThrow(() => { text = transcriptToText(runner); });
+  assert.match(text, /TOOL_USE\(read\)/);
+  assert.match(text, /structured/, "structured content is JSON-stringified into the text");
+  assert.match(text, /TOOL_RESULT\(t2\): 42/, "numeric content is coerced, not dropped");
+});
+
+test("prepareWorkdir git-clone is async and honors an AbortSignal instead of blocking uncancellably", async () => {
+  const { prepareWorkdir } = await import("../lib/executor");
+  // A real source repo to clone — proves the clone would otherwise succeed, so
+  // the rejection is the signal doing its job, not a broken repo.
+  const srcRepo = await fsp.mkdtemp(path.join(os.tmpdir(), "openeval-clone-src-"));
+  fs.writeFileSync(path.join(srcRepo, "file.txt"), "content\n");
+  execFileSync("git", ["init", "-q"], { cwd: srcRepo });
+  execFileSync("git", ["add", "-A"], { cwd: srcRepo });
+  execFileSync("git", ["-c", "user.email=eval@local", "-c", "user.name=eval", "commit", "-q", "-m", "seed"], { cwd: srcRepo });
+
+  const controller = new AbortController();
+  controller.abort();
+  const def = caseDef({ id: "edge-clone-abort", setup: { type: "git-clone", repo: srcRepo }, graders: [{ type: "manual" }] });
+  // With the old synchronous execFileSync the signal was ignored and the clone
+  // completed regardless; this must now reject as a cancelled/handled clone.
+  await assert.rejects(
+    prepareWorkdir("run-edges", def.id, def, 0, controller.signal),
+    "an aborted signal must interrupt the git clone",
+  );
+  await fsp.rm(srcRepo, { recursive: true, force: true }).catch(() => {});
+});
+
+test("an appendEvent (SQLite) throw on the runner hot path does not abort the in-flight case", async () => {
+  const { executeCase } = await import("../lib/executor");
+  const db = await import("../lib/db");
+  await ensureRun("run-edges");
+
+  // Inject the fault at the SQLite seam (better-sqlite3 handle), mirroring a
+  // transient SQLITE_BUSY/serialization error on the events insert that
+  // appendEvent runs from the onEvent hot path. Only the hot-path event kinds
+  // (bound as the 3rd param of the events INSERT) throw; the unguarded
+  // lifecycle events (case_started/case_grading/case_finished) pass through, so
+  // this test isolates the onEvent guard specifically.
+  const hotKinds = new Set(["tool_use", "tool_result", "assistant_message"]);
+  const handle = db.getDb();
+  const realPrepare = handle.prepare.bind(handle);
+  (handle as { prepare: typeof handle.prepare }).prepare = ((sql: string) => {
+    const stmt = realPrepare(sql);
+    if (typeof sql === "string" && sql.includes("INSERT INTO events")) {
+      const realRun = stmt.run.bind(stmt);
+      (stmt as { run: typeof stmt.run }).run = ((...args: unknown[]) => {
+        if (hotKinds.has(args[2] as string)) throw new Error("SQLITE_BUSY: database is locked");
+        return realRun(...(args as Parameters<typeof stmt.run>));
+      }) as typeof stmt.run;
+    }
+    return stmt;
+  }) as typeof handle.prepare;
+  let rec;
+  try {
+    const def = caseDef({
+      id: "edge-appendevent-throw",
+      graders: [{ type: "regex_match", pattern: "hello world", source: "final_text" }],
+    });
+    rec = await executeCase("run-edges", def, "headless", 21, undefined, 0, undefined);
+  } finally {
+    (handle as { prepare: typeof handle.prepare }).prepare = realPrepare;
+  }
+  assert.equal(rec.status, "passed", "a swallowed hot-path event write must not fail the case");
 });
 
 // ---- orphan sweep liveness guard ----


### PR DESCRIPTION
## Summary
Three robustness fixes confined to `lib/executor.ts`, each preventing a class of run-wide failure or spurious error.

1. **Blocking, uncancellable git** — `prepareWorkdir` used synchronous `execFileSync`/`execSync` for `git clone` and the baseline commit, with no `timeout` and ignoring the run's `AbortSignal`. A stalled network clone blocked the entire event loop, freezing all parallel workers, the SSE heartbeat, and the dashboard, and could not be cancelled. Converted to promisified `execFile` with a `timeout` and the run's `signal` threaded through `prepareWorkdir`. The `init_git` `git init && git add && git commit` shell chain is split into three shell-free `execFile` calls, preserving short-circuit-on-failure and the original silent-swallow-of-init-failure semantics.

2. **Unguarded DB writes on the hot path** — the `appendEvent` SQLite writes inside the `onEvent` callback were not wrapped, so a transient `SQLITE_BUSY`/serialization throw escaped uncaught and aborted the in-flight case (the sibling transcript `fs.appendFile` was already `.catch`-guarded). Wrapped in `try/catch` — these live-feed events are best-effort telemetry; grading reads from the settled transcript, not this stream.

3. **`transcriptToText` non-string content** — it assumed `tool_result.content` is a string and called `.slice()` on it. The built-in stream-json parser coerces upstream, but a descriptor/custom adapter (or an externally reconstructed transcript) can supply a structured block, which threw and turned a gradeable run into a spurious `error`. Now coerced via a safe JSON stringify.

## Tests
Regression tests added to `tests/executor-edges.test.ts`, each verified to **fail without its fix**:
- `transcriptToText` coerces a non-string `tool_result` content instead of throwing (direct unit test on the now-exported function — the honest reproduction, since the stream-json parser coerces before the pipeline could reach the bug).
- `prepareWorkdir` git-clone honors an `AbortSignal` (rejects instead of blocking uncancellably).
- A hot-path `appendEvent` SQLite throw does not abort the in-flight case (fault injected at the better-sqlite3 `prepare`/`run` seam, scoped to hot-path event kinds only).

`npm run typecheck`, `tests/executor.test.ts` (13), `tests/executor-edges.test.ts` (13), and `npm run selftest` (26 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)