### PR TITLE
evals: add swe-trace-test-first case exercising the step/trace grader tier

### DIFF
--- a/cases/agentic-swe/oracle/swe-trace-test-first-hardcode-bad.sh
+++ b/cases/agentic-swe/oracle/swe-trace-test-first-hardcode-bad.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Known-bad: hard-codes the two values the shipped tests check. `npm test`
+# passes, but the fix is wrong for every other input, so the broader
+# exit_code oracle rejects it. This is why tests alone are not a sufficient
+# grader for this case.
+cat > src/range.js <<'JS'
+function rangeSum(n) {
+  if (n === 5) return 15;
+  if (n === 1) return 1;
+  return 0;
+}
+
+module.exports = { rangeSum };
+JS

--- a/cases/agentic-swe/oracle/swe-trace-test-first.sh
+++ b/cases/agentic-swe/oracle/swe-trace-test-first.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Correct fix: make the loop bound inclusive so n is added to the sum.
+cat > src/range.js <<'JS'
+function rangeSum(n) {
+  let total = 0;
+  for (let i = 1; i <= n; i++) {
+    total += i;
+  }
+  return total;
+}
+
+module.exports = { rangeSum };
+JS

--- a/cases/agentic-swe/swe-trace-test-first.case.json
+++ b/cases/agentic-swe/swe-trace-test-first.case.json
@@ -1,0 +1,64 @@
+{
+  "id": "swe-trace-test-first",
+  "difficulty": "medium",
+  "category": "agentic-swe",
+  "name": "Fix rangeSum test-first",
+  "description": "rangeSum(n) should return the sum of 1..n but its loop bound is exclusive, so n is never added. The agent must reproduce the failure by running the tests BEFORE touching the source, fix the loop bound, then re-run the tests to confirm. This case exercises the trace/step evidence tier: `step` graders assert the tool-call ORDER (run tests before editing) in addition to the deterministic fix graders.",
+  "tags": [
+    "bugfix",
+    "node",
+    "tests",
+    "trace",
+    "test-first"
+  ],
+  "prompt": "There is a bug in src/range.js: rangeSum(n) should return 1+2+...+n but it currently drops the final term (e.g. rangeSum(5) returns 10 instead of 15). Work test-first: FIRST run `npm test` to watch the failing tests, THEN fix the loop bound in src/range.js, THEN run `npm test` again to confirm every test passes. Do not modify the test file or package.json.",
+  "setup": {
+    "type": "fixture",
+    "fixture": "range-sum-repo",
+    "init_git": true
+  },
+  "runner": {
+    "max_turns": 18,
+    "timeout_seconds": 240,
+    "permission_mode": "bypassPermissions"
+  },
+  "graders": [
+    {
+      "type": "tests_pass",
+      "command": "npm test",
+      "timeout_ms": 30000
+    },
+    {
+      "type": "exit_code",
+      "command": "node -e \"const {rangeSum}=require('./src/range'); if(rangeSum(10)!==55||rangeSum(100)!==5050) process.exit(1)\""
+    },
+    {
+      "type": "files_unchanged",
+      "paths": [
+        "src/range.test.js",
+        "package.json"
+      ],
+      "forbidden": true
+    },
+    {
+      "type": "step",
+      "tool": "Bash",
+      "input_includes": "test",
+      "before_tool": "Edit"
+    },
+    {
+      "type": "step",
+      "tool": "Bash",
+      "input_includes": "test",
+      "min_count": 2
+    }
+  ],
+  "pass_threshold": 0.5,
+  "oracle": {
+    "solve": "oracle/swe-trace-test-first.sh",
+    "noop_max_score": 0.25,
+    "known_bad": [
+      "oracle/swe-trace-test-first-hardcode-bad.sh"
+    ]
+  }
+}

--- a/fixtures/range-sum-repo/package.json
+++ b/fixtures/range-sum-repo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "range-sum-repo",
+  "version": "1.0.0",
+  "scripts": { "test": "node --test src/range.test.js" }
+}

--- a/fixtures/range-sum-repo/src/range.js
+++ b/fixtures/range-sum-repo/src/range.js
@@ -1,0 +1,10 @@
+function rangeSum(n) {
+  let total = 0;
+  // BUG: the upper bound is exclusive, so n itself is never added.
+  for (let i = 1; i < n; i++) {
+    total += i;
+  }
+  return total;
+}
+
+module.exports = { rangeSum };

--- a/fixtures/range-sum-repo/src/range.test.js
+++ b/fixtures/range-sum-repo/src/range.test.js
@@ -1,0 +1,11 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { rangeSum } = require("./range");
+
+test("sums 1..5 to 15", () => {
+  assert.equal(rangeSum(5), 15);
+});
+
+test("sums the single element 1..1 to 1", () => {
+  assert.equal(rangeSum(1), 1);
+});


### PR DESCRIPTION
## What

Adds one new agentic-swe case (`swe-trace-test-first`) plus a new fixture (`range-sum-repo`) that exercises the `step` grader — the entire **trace** evidence tier, which was fully implemented in `lib/grader/index.ts` but used by **zero** cases (so the tier was untested by the corpus).

New files only; no existing case/fixture/lib touched.

## The case

- **Bug**: `rangeSum(n)` uses an exclusive loop bound (`i < n`), so it drops the final term (`rangeSum(5)` returns 10 instead of 15). Failing test ships in the fixture; `init_git: true` for a baseline.
- **Deterministic backstop**: `tests_pass` (`npm test`), a broader `exit_code` correctness check (`rangeSum(10)===55`, `rangeSum(100)===5050`), and `files_unchanged` (forbidden) on the test file + `package.json`.
- **Trace assertions** (`step`): a `before_tool` grader (a `npm test` Bash call must precede the first `Edit`) and a `min_count: 2` grader (reproduce the failure, then verify the fix).
- **Full oracle**: `solve` (correct inclusive-bound fix) and `known_bad` — a hard-code shortcut that passes the two shipped tests but fails the broader `exit_code` oracle, demonstrating why tests alone are an insufficient grader here.

## Verification

- `npm run typecheck` clean; `tests/cases-schema.test.ts` 7/7 pass.
- `npm run audit:accuracy --strict`: exit 0, case has zero weaknesses; **Trace tier is now 2 (was 0)**.
- `npm run selftest`: 0 fail — oracle `solve` passes, `known_bad[0]` rejected (score 0.40 < 0.5 threshold), no-op below `noop_max_score`.
- Synthetic-trace proof (step grader can't be validated by the empty-trace oracle loop, so proven directly): correct fix with **good order** (test -> edit -> test) scores 1.00 with both step graders passing; correct fix with **bad order** (edit -> test) fails both step graders (`expected Bash call before first Edit`, `only 1 matching step, needed >= 2`).

`pass_threshold` is 0.5: this keeps the empty-trace oracle self-test green (the oracle loop runs bash scripts with no tool-call trace, so `step` graders can only be validated against synthetic traces) while the step graders still flag wrong-order traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)